### PR TITLE
Parallel compile and assemble

### DIFF
--- a/lib/mlton/basic/process.sig
+++ b/lib/mlton/basic/process.sig
@@ -101,6 +101,8 @@ signature PROCESS =
                        ppid: Pid.t,
                        state: State.t} list
 
+      val numberOfMLtonJobs : unit -> int
+      val foreachPar : int * 'a list * ('a -> unit) -> unit
    end
 
 functor TestProcess (S: PROCESS): sig end =

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1453,12 +1453,10 @@ fun commandLine (args: string list): unit =
                                 (commands :: allCommands, output :: allOutputs)
                              end))
                            ()
-                        fun doCommands commands =
-                          List.foreach (commands, System.system)
-                        fun doAllCommandsPar allCommands =
-                          List.foreach (allCommands, doCommands);
+
+                        fun doIt l = List.foreach (l, System.system)
                      in
-                        doAllCommandsPar (rev allCommands);
+                        Process.foreachPar (Process.numberOfMLtonJobs (), rev allCommands, doIt);
                         case stop of
                            Place.O => ()
                          | _ => compileO (rev oFiles)


### PR DESCRIPTION
MLton spends a non-negligible amount of time calling gcc when compiling a large SML program with its C backend. This is particularly acute when bootstrapping. These commits speed up this process by making MLton call gcc in parallel. The number of parallel processes is controlled by the MLTON_JOBS environment variable.

The implementation is naive, but I believe sufficient for our purposes. MLton randomly divides the J calls to gcc into N buckets containing roughly J/N jobs each. It then forks off N sub-processes, each of them executing the jobs of a single bucket sequentially. This logic is contained in the function Process.foreachPar.