### PR TITLE
Added a version of CAS to MLton.Parallel for arrays

### DIFF
--- a/basis-library/mlton/parallel.sig
+++ b/basis-library/mlton/parallel.sig
@@ -58,6 +58,13 @@ signature MLTON_PARALLEL =
                  * Creates an uninitialized array of given size.
                  *)
                 val arrayUninit: int -> 'a Array.array
+                 
+                (**
+                 * `arrayCompareAndSwap (xs, i, old, new)` performs a CAS
+                 * of (old, new) at xs[i]. This implementation does not
+                 * do bounds checking on i.
+                 *)
+                val arrayCompareAndSwap : Int32.int array * Int32.int * Int32.int * Int32.int -> bool
               end
 
     exception Return
@@ -89,7 +96,13 @@ signature MLTON_PARALLEL =
      * registerProcessorFunction before calling this function!
      *)
     val initializeProcessors: unit -> unit;
- 
+
+    (**
+     * `arrayCompareAndSwap (xs, i, old, new)` performs a CAS
+     * of (old, new) at xs[i]. If i is out of bounds, it raises Subscript.
+     *)
+    val arrayCompareAndSwap : Int32.int array * Int32.int * Int32.int * Int32.int -> bool
+
     (* shwestrick: needed these for private-deqs scheduler *)
     val compareAndSwap : Int32.int ref * Int32.int * Int32.int -> bool
     val fetchAndAdd : Int32.int ref * Int32.int -> Int32.int

--- a/basis-library/mlton/parallel.sml
+++ b/basis-library/mlton/parallel.sml
@@ -58,6 +58,7 @@ structure MLtonParallel:> MLTON_PARALLEL =
             MLtonThread.initPrimitive
         val arrayUninit: int -> 'a Array.array =
             Array.arrayUninit
+        val arrayCompareAndSwap = _import "Parallel_arrayCompareAndSwap" impure private: Int32.int array * Int32.int * Int32.int * Int32.int -> bool;
       end
 
     exception Return
@@ -75,6 +76,11 @@ structure MLtonParallel:> MLTON_PARALLEL =
 
     val initializeProcessors: unit -> unit =
         _import "Parallel_init" runtime private: unit -> unit;
+
+    fun arrayCompareAndSwap (xs, i, old, new) =
+      if i < 0 orelse i >= Array.length xs
+      then raise Subscript
+      else Unsafe.arrayCompareAndSwap (xs, i, old, new)
 
     (* shwestrick: needed these for private-deqs scheduler *)
     val compareAndSwap = _import "Parallel_compareAndSwap" impure private: Int32.int ref * Int32.int * Int32.int -> bool;

--- a/runtime/gc/parallel.c
+++ b/runtime/gc/parallel.c
@@ -193,3 +193,7 @@ Int32 Parallel_fetchAndAdd (pointer p, Int32 v) {
 bool Parallel_compareAndSwap (pointer p, Int32 old, Int32 new) {
   return __sync_bool_compare_and_swap ((Int32 *)p, old, new);
 }
+
+bool Parallel_arrayCompareAndSwap (Pointer p, Int32 i, Int32 old, Int32 new) {
+  return __sync_bool_compare_and_swap (((Int32*)p)+i, old, new);
+}

--- a/runtime/gc/parallel.h
+++ b/runtime/gc/parallel.h
@@ -19,5 +19,6 @@ PRIVATE Word64 Parallel_getTimeInGC (void);
 
 PRIVATE Int32 Parallel_fetchAndAdd (pointer p, Int32 v);
 PRIVATE bool Parallel_compareAndSwap (pointer p, Int32 old, Int32 new);
+PRIVATE bool Parallel_arrayCompareAndSwap (Pointer, Int32, Int32, Int32);
 
 #endif /* (defined (MLTON_GC_INTERNAL_BASIS)) */


### PR DESCRIPTION
Added two functions:

- `MLton.Parallel.arrayCompareAndSwap (xs, i, old, new)` tries to swap `old` with `new` at `xs[i]`, and raises `Subscript` if `i` is out of bounds.

- `MLton.Parallel.Unsafe.arrayCompareAndSwap (xs, i, old, new)` does the same, but with no bounds checking.