### PR TITLE
runtime: Improve LCHS resizing

### DIFF
--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -20,7 +20,8 @@
 #if (defined (MLTON_GC_INTERNAL_TYPES))
 enum HM_HHState {
   LIVE = 0,
-  DEAD = 1
+  DEAD = 1,
+  MERGED = 2
 };
 
 extern const char* HM_HHStateToString[];
@@ -304,6 +305,15 @@ Word32 HM_HH_getHighestStolenLevel(GC_state s,
                                    const struct HM_HierarchicalHeap* hh);
 
 /**
+ * Gets the frontier from a struct HM_HierarchicalHeap
+ *
+ * @param hh The struct HM_HierarchicalHeap to use
+ *
+ * @return the frontier of the currently active chunk.
+ */
+void* HM_HH_getFrontier(const struct HM_HierarchicalHeap* hh);
+
+/**
  * Gets the heap limit from a struct HM_HierarchicalHeap
  *
  * @param hh The struct HM_HierarchicalHeap to use
@@ -313,13 +323,13 @@ Word32 HM_HH_getHighestStolenLevel(GC_state s,
 void* HM_HH_getLimit(const struct HM_HierarchicalHeap* hh);
 
 /**
- * Gets the frontier from a struct HM_HierarchicalHeap
+ * Returns the current lchs/lcs ratio
  *
- * @param hh The struct HM_HierarchicalHeap to use
+ * @param hh The HH to get the ratio of
  *
- * @return the frontier of the currently active chunk.
+ * @return The ratio.
  */
-void* HM_HH_getFrontier(const struct HM_HierarchicalHeap* hh);
+double HM_HH_getLCRatio(const struct HM_HierarchicalHeap* hh);
 
 /**
  * Resizes the locally collectible heap size, if necessary, according the

--- a/runtime/gc/local-heap.c
+++ b/runtime/gc/local-heap.c
@@ -83,8 +83,7 @@ void HM_ensureHierarchicalHeapAssurances(GC_state s,
         ((void*)(s->frontier)));
   }
 
-  double allocatedRatio = ((double)(hh->locallyCollectibleHeapSize)) /
-                          ((double)(hh->locallyCollectibleSize));
+  double allocatedRatio = HM_HH_getLCRatio(hh);
   Trace3(EVENT_CHUNKP_RATIO,
          hh->locallyCollectibleHeapSize,
          hh->locallyCollectibleSize,
@@ -93,8 +92,7 @@ void HM_ensureHierarchicalHeapAssurances(GC_state s,
     /* too much allocated, so let's collect */
     HM_HHC_collectLocal();
 
-    double newAllocatedRatio = ((double)(hh->locallyCollectibleHeapSize)) /
-                               ((double)(hh->locallyCollectibleSize));
+    double newAllocatedRatio = HM_HH_getLCRatio(hh);
     Trace3(EVENT_CHUNKP_RATIO,
            hh->locallyCollectibleHeapSize,
            hh->locallyCollectibleSize,


### PR DESCRIPTION
We now also resize on appendChild() (keep the ratio the same) and
mergeIntoParent() (use lesser of two ratios).