### PR TITLE
runtime: Fix entanglement bug due to fragmentation optimization.

### DIFF
--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -172,7 +172,7 @@ void HM_HH_mergeIntoParent(pointer hhPointer) {
 
   if (getThreadCurrent(s)->useHierarchicalHeap &&
       !HM_inGlobalHeap(s)) {
-    HM_ensureHierarchicalHeapAssurances(s, false, 0, true);
+    HM_ensureHierarchicalHeapAssurances(s, false, GC_HEAP_LIMIT_SLOP, true);
   }
 
   endAtomic (s);


### PR DESCRIPTION
Our fragmentation optimization (i.e. where you allocate in an
ancestor's chunk) can cause entanglement on superheap merge. This can
happen when the parent superheap's allocation is occurring at an
ancestor of the merged superheap, leading to a pointer from the
ancestor chunk to the return value of the merged child superheap at a
lower depth.

This commit fixes this bug by enforcing that the parent superheap is
allocating at the current depth before merging in the child
superheap.