### PR TITLE
Primitives for reading a file in parallel

### DIFF
--- a/basis-library/build/sources.mlb
+++ b/basis-library/build/sources.mlb
@@ -394,11 +394,7 @@ in
    ../mlton/mlton.sml
 
    ../mpl/file.sig
-   ann
-      "allowFFI true"
-   in
-      ../mpl/file.sml
-   end
+   ../mpl/file.sml
    ../mpl/mpl.sig
    ../mpl/mpl.sml
 

--- a/basis-library/build/sources.mlb
+++ b/basis-library/build/sources.mlb
@@ -393,6 +393,15 @@ in
    ../mlton/mlton.sig
    ../mlton/mlton.sml
 
+   ../mpl/file.sig
+   ann
+      "allowFFI true"
+   in
+      ../mpl/file.sml
+   end
+   ../mpl/mpl.sig
+   ../mpl/mpl.sml
+
    ../sml-nj/sml-nj.sig
    ../sml-nj/sml-nj.sml
    ../sml-nj/unsafe.sig

--- a/basis-library/libs/all.mlb
+++ b/basis-library/libs/all.mlb
@@ -12,6 +12,7 @@ local
    ../basis-1997.mlb
    ../basis-none.mlb
    ../mlton.mlb
+   ../mpl.mlb
    ../sml-nj.mlb
    ../unsafe.mlb
    ../c-types.mlb

--- a/basis-library/libs/basis-extra/top-level/basis-sigs.sml
+++ b/basis-library/libs/basis-extra/top-level/basis-sigs.sml
@@ -116,3 +116,6 @@ signature MLTON_WORD = MLTON_WORD
 signature MLTON_WORLD = MLTON_WORLD
 signature SML_OF_NJ = SML_OF_NJ
 signature UNSAFE = UNSAFE
+
+signature MPL = MPL
+signature MPL_FILE = MPL_FILE

--- a/basis-library/libs/basis-extra/top-level/basis.sig
+++ b/basis-library/libs/basis-extra/top-level/basis.sig
@@ -327,7 +327,7 @@ signature BASIS_EXTRA =
       structure MLton: MLTON
       structure SMLofNJ: SML_OF_NJ
       structure Unsafe: UNSAFE
-      structure Mpl: MPL
+      structure MPL: MPL
 
       sharing type MLton.IntInf.t = IntInf.int
       sharing type MLton.Process.pid = Posix.Process.pid

--- a/basis-library/libs/basis-extra/top-level/basis.sig
+++ b/basis-library/libs/basis-extra/top-level/basis.sig
@@ -327,6 +327,7 @@ signature BASIS_EXTRA =
       structure MLton: MLTON
       structure SMLofNJ: SML_OF_NJ
       structure Unsafe: UNSAFE
+      structure Mpl: MPL
 
       sharing type MLton.IntInf.t = IntInf.int
       sharing type MLton.Process.pid = Posix.Process.pid

--- a/basis-library/libs/basis-extra/top-level/basis.sml
+++ b/basis-library/libs/basis-extra/top-level/basis.sml
@@ -256,7 +256,7 @@ structure BasisExtra :> BASIS_EXTRA =
       structure MLton = MLton
       structure SMLofNJ = SMLofNJ
       structure Unsafe = Unsafe
-      structure Mpl = Mpl
+      structure MPL = MPL
 
       open ArrayGlobal
            BoolGlobal

--- a/basis-library/libs/basis-extra/top-level/basis.sml
+++ b/basis-library/libs/basis-extra/top-level/basis.sml
@@ -5,7 +5,7 @@
  * See the file MLton-LICENSE for details.
  *)
 
-structure BasisExtra :> BASIS_EXTRA = 
+structure BasisExtra :> BASIS_EXTRA =
    struct
       (* Required structures *)
       structure Array = Array
@@ -256,6 +256,7 @@ structure BasisExtra :> BASIS_EXTRA =
       structure MLton = MLton
       structure SMLofNJ = SMLofNJ
       structure Unsafe = Unsafe
+      structure Mpl = Mpl
 
       open ArrayGlobal
            BoolGlobal

--- a/basis-library/libs/basis-extra/top-level/top-level.sml
+++ b/basis-library/libs/basis-extra/top-level/top-level.sml
@@ -12,5 +12,5 @@ in
   structure MLton = MLton
   structure SMLofNJ = SMLofNJ
   structure Unsafe = Unsafe
-  structure Mpl = Mpl
+  structure MPL = MPL
 end

--- a/basis-library/libs/basis-extra/top-level/top-level.sml
+++ b/basis-library/libs/basis-extra/top-level/top-level.sml
@@ -12,4 +12,5 @@ in
   structure MLton = MLton
   structure SMLofNJ = SMLofNJ
   structure Unsafe = Unsafe
+  structure Mpl = Mpl
 end

--- a/basis-library/mpl.mlb
+++ b/basis-library/mpl.mlb
@@ -1,0 +1,21 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+ann
+   "deadCode true"
+   "nonexhaustiveBind warn" "nonexhaustiveMatch warn"
+   "redundantBind warn" "redundantMatch warn"
+   "sequenceNonUnit warn"
+   "warnUnused true" "forceUsed"
+in
+   local
+      libs/basis-extra/basis-extra.mlb
+   in
+      signature MPL_FILE
+      signature MPL
+      structure Mpl
+   end
+end

--- a/basis-library/mpl.mlb
+++ b/basis-library/mpl.mlb
@@ -16,6 +16,6 @@ in
    in
       signature MPL_FILE
       signature MPL
-      structure Mpl
+      structure MPL
    end
 end

--- a/basis-library/mpl/file.sig
+++ b/basis-library/mpl/file.sig
@@ -1,0 +1,21 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+signature MPL_FILE =
+sig
+  type t
+
+  exception Closed
+
+  val openFile: string -> t
+  val closeFile: t -> unit
+  val size: t -> int
+
+  val readChar: t -> int -> char
+  val readWord8: t -> int -> Word8.word
+  val unsafeReadChar: t -> int -> char
+  val unsafeReadWord8: t -> int -> Word8.word
+end

--- a/basis-library/mpl/file.sig
+++ b/basis-library/mpl/file.sig
@@ -18,4 +18,7 @@ sig
   val readWord8: t -> int -> Word8.word
   val unsafeReadChar: t -> int -> char
   val unsafeReadWord8: t -> int -> Word8.word
+
+  val readChars: t -> int -> char ArraySlice.slice -> unit
+  val readWord8s: t -> int -> Word8.word ArraySlice.slice -> unit
 end

--- a/basis-library/mpl/file.sml
+++ b/basis-library/mpl/file.sml
@@ -30,6 +30,7 @@ struct
       val fd = C_Int.fromInt (SysWord.toInt (fdToWord file))
       val ptr = mmapFileReadable (fd, C_Size.fromInt size)
     in
+      Posix.IO.close file;
       (ptr, size, ref true)
     end
 

--- a/basis-library/mpl/file.sml
+++ b/basis-library/mpl/file.sml
@@ -1,0 +1,67 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+structure MPLFile :> MPL_FILE =
+struct
+  local
+    open Primitive.MLton.Pointer
+  in
+  structure C_Size = C_Size
+  structure C_Int = C_Int
+  end
+
+  type t = MLton.Pointer.t * int * bool ref
+
+  val mmapFileReadable = _import "GC_mmapFileReadable" runtime private:
+    C_Int.int * C_Size.word -> MLton.Pointer.t;
+  val release = _import "GC_release" runtime private:
+    MLton.Pointer.t * C_Size.word -> unit;
+
+  fun openFile path =
+    let
+      open Posix.FileSys
+      val file = openf (path, O_RDONLY, O.fromWord 0w0)
+      val size = Position.toInt (ST.size (fstat file))
+      val fd = C_Int.fromInt (SysWord.toInt (fdToWord file))
+      val ptr = mmapFileReadable (fd, C_Size.fromInt size)
+    in
+      (ptr, size, ref true)
+    end
+
+  exception Closed
+
+  fun closeFile (ptr, size, stillOpen) =
+    if !stillOpen then
+      (release (ptr, C_Size.fromInt size); stillOpen := false)
+    else
+      raise Closed
+
+  fun unsafeReadWord8 (ptr, _, _) i =
+    MLton.Pointer.getWord8 (ptr, i)
+
+  fun unsafeReadChar (ptr, _, _) i =
+    Char.chr (Word8.toInt (MLton.Pointer.getWord8 (ptr, i)))
+
+  fun readChar (ptr, size, stillOpen) (i: int) =
+    if !stillOpen andalso i >= 0 andalso i < size then
+      unsafeReadChar (ptr, size, stillOpen) i
+    else if i < 0 orelse i >= size then
+      raise Subscript
+    else
+      raise Closed
+
+  fun readWord8 (ptr, size, stillOpen) (i: int) =
+    if !stillOpen andalso i >= 0 andalso i < size then
+      unsafeReadWord8 (ptr, size, stillOpen) i
+    else if i < 0 orelse i >= size then
+      raise Subscript
+    else
+      raise Closed
+
+  fun size (ptr, sz, stillOpen) =
+    if !stillOpen then sz else raise Closed
+
+end

--- a/basis-library/mpl/file.sml
+++ b/basis-library/mpl/file.sml
@@ -17,7 +17,7 @@ struct
 
   exception Closed
 
-  open Primitive.Mpl.File
+  open Primitive.MPL.File
 
   fun size (ptr, sz, stillOpen) =
     if !stillOpen then sz else raise Closed

--- a/basis-library/mpl/file.sml
+++ b/basis-library/mpl/file.sml
@@ -15,14 +15,9 @@ struct
 
   type t = MLton.Pointer.t * int * bool ref
 
-  val copyCharsToBuffer = _import "GC_memcpyToBuffer" runtime private:
-    MLton.Pointer.t * char array * C_Size.word * C_Size.word -> unit;
-  val copyWord8sToBuffer = _import "GC_memcpyToBuffer" runtime private:
-    MLton.Pointer.t * Word8.word array * C_Size.word * C_Size.word -> unit;
-  val mmapFileReadable = _import "GC_mmapFileReadable" runtime private:
-    C_Int.int * C_Size.word -> MLton.Pointer.t;
-  val release = _import "GC_release" runtime private:
-    MLton.Pointer.t * C_Size.word -> unit;
+  exception Closed
+
+  open Primitive.Mpl.File
 
   fun size (ptr, sz, stillOpen) =
     if !stillOpen then sz else raise Closed
@@ -37,8 +32,6 @@ struct
     in
       (ptr, size, ref true)
     end
-
-  exception Closed
 
   fun closeFile (ptr, size, stillOpen) =
     if !stillOpen then

--- a/basis-library/mpl/mpl.sig
+++ b/basis-library/mpl/mpl.sig
@@ -1,0 +1,10 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+signature MPL =
+sig
+  structure File: MPL_FILE
+end

--- a/basis-library/mpl/mpl.sml
+++ b/basis-library/mpl/mpl.sml
@@ -1,0 +1,10 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+structure Mpl :> MPL =
+struct
+  structure File = MPLFile
+end

--- a/basis-library/mpl/mpl.sml
+++ b/basis-library/mpl/mpl.sml
@@ -4,7 +4,7 @@
  * See the file MLton-LICENSE for details.
  *)
 
-structure Mpl :> MPL =
+structure MPL :> MPL =
 struct
   structure File = MPLFile
 end

--- a/basis-library/primitive/prim-mpl.sml
+++ b/basis-library/primitive/prim-mpl.sml
@@ -7,7 +7,7 @@
 structure Primitive = struct
 open Primitive
 
-structure Mpl =
+structure MPL =
 struct
 
   structure File =

--- a/basis-library/primitive/prim-mpl.sml
+++ b/basis-library/primitive/prim-mpl.sml
@@ -1,0 +1,27 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+structure Primitive = struct
+open Primitive
+
+structure Mpl =
+struct
+
+  structure File =
+  struct
+    val copyCharsToBuffer = _import "GC_memcpyToBuffer" runtime private:
+      Pointer.t * Char8.t array * C_Size.word * C_Size.word -> unit;
+    val copyWord8sToBuffer = _import "GC_memcpyToBuffer" runtime private:
+      Pointer.t * Word8.word array * C_Size.word * C_Size.word -> unit;
+    val mmapFileReadable = _import "GC_mmapFileReadable" runtime private:
+      C_Int.int * C_Size.word -> Pointer.t;
+    val release = _import "GC_release" runtime private:
+      Pointer.t * C_Size.word -> unit;
+  end
+
+end
+
+end

--- a/basis-library/primitive/primitive.mlb
+++ b/basis-library/primitive/primitive.mlb
@@ -70,6 +70,7 @@ in
    prim-pack-real.sml
 
    prim-mlton.sml
+   prim-mpl.sml
 
    basis-ffi.sml
    prim2.sml

--- a/runtime/gc/virtual-memory.c
+++ b/runtime/gc/virtual-memory.c
@@ -32,6 +32,10 @@ static inline void GC_memcpy (pointer src, pointer dst, size_t size) {
   memcpy (dst, src, size);
 }
 
+void GC_memcpyToBuffer(pointer src, pointer buffer, size_t offset, size_t length) {
+  GC_memcpy(src, buffer + offset, length);
+}
+
 static inline void GC_memmove (pointer src, pointer dst, size_t size) {
   if (DEBUG_DETAILED)
     fprintf (stderr, "GC_memmove ("FMTPTR", "FMTPTR", %"PRIuMAX")\n",

--- a/runtime/platform.h
+++ b/runtime/platform.h
@@ -122,6 +122,8 @@ PRIVATE __attribute__ ((noreturn)) void MLton_heapCheckTooLarge (void);
  */
 PRIVATE void GC_displayMem (void);
 
+PRIVATE void GC_memcpyToBuffer(pointer src, pointer buffer, size_t offset, size_t length);
+
 PRIVATE void *GC_mmapFileReadable (int fd, size_t size);
 PRIVATE void *GC_mmapAnon (void *start, size_t length);
 PRIVATE void *GC_mmapAnonFlags (void *start, size_t length, int flags);

--- a/runtime/platform.h
+++ b/runtime/platform.h
@@ -122,6 +122,7 @@ PRIVATE __attribute__ ((noreturn)) void MLton_heapCheckTooLarge (void);
  */
 PRIVATE void GC_displayMem (void);
 
+PRIVATE void *GC_mmapFileReadable (int fd, size_t size);
 PRIVATE void *GC_mmapAnon (void *start, size_t length);
 PRIVATE void *GC_mmapAnonFlags (void *start, size_t length, int flags);
 PRIVATE void *GC_mmapAnon_safe (void *start, size_t length);

--- a/runtime/platform/mmap.c
+++ b/runtime/platform/mmap.c
@@ -1,5 +1,9 @@
+static inline void *mmapFileReadable (int fd, size_t size) {
+  return mmap (0, size, PROT_READ, MAP_PRIVATE, fd, 0);
+}
+
 static inline void *mmapAnonFlags (void *start, size_t length, int flags) {
-        return mmap (start, length, PROT_READ | PROT_WRITE, 
+        return mmap (start, length, PROT_READ | PROT_WRITE,
                         MAP_PRIVATE | MAP_ANON | flags, -1, 0);
 }
 

--- a/runtime/platform/use-mmap.c
+++ b/runtime/platform/use-mmap.c
@@ -4,6 +4,10 @@ void GC_release (void *base, size_t length) {
         munmap_safe (base, length);
 }
 
+void *GC_mmapFileReadable (int fd, size_t size) {
+  return mmapFileReadable(fd, size);
+}
+
 void *GC_mmapAnon (void *start, size_t length) {
         return mmapAnon (start, length);
 }


### PR DESCRIPTION
In our benchmarking, we've run into a recurring issue that it is unreasonably slow to read large files with basis IO functionality (e.g. `TextIO.inputAll`). The obvious alternative would be to use `Posix.IO` and `Posix.FileSys`, and indeed these are fast sequentially, but they also unfortunately provide no opportunity for parallelism.

There is a standard trick to work around the lack of parallelism with POSIX: just `mmap` files into memory and then read from them directly. This is fast sequentially and highly parallel. So, I implemented it in MPL.

## Library Spec
This patch provides a structure `MPL.File` with this signature:
```
signature MPL_FILE =
sig
  type t

  exception Closed

  val openFile: string -> t
  val closeFile: t -> unit
  val size: t -> int

  val readChar: t -> int -> char
  val readWord8: t -> int -> Word8.word
  val unsafeReadChar: t -> int -> char
  val unsafeReadWord8: t -> int -> Word8.word

  val readChars: t -> int -> char ArraySlice.slice -> unit
  val readWord8s: t -> int -> Word8.word ArraySlice.slice -> unit
end
```

A file of type `MPL.File.t` can be created by passing a path string to `openFile`, which mmaps the file into memory (as private and read-only). Later, **you must explicitly close the file** with `closeFile` to free up this memory. Otherwise, there will be a space leak.

The functions `readChars` and `readWord8s` take a file, an offset, and an output buffer, and copy enough bytes from the file (starting at the given offset) to fill up the output buffer. These can be safely called in parallel, even on overlapping regions of the file, but the output buffers must be disjoint to avoid data races. The one-byte versions `readChar` and `readWord8` just return the byte at the given offset.

Except for the `unsafe` functions, if you attempt to read outside the range of the file, the exception `Subscript` will be raised, and any operation on a closed file will raise `Closed`. Note that closing a file is not safe for concurrency (e.g., if you close a file while concurrently reading from it, this could crash). This is something that needs to be fixed in the future.

## Intended Use
Here is a function defined in terms of `MPL.File` that reads a file in parallel. It behaves as though it were purely functional.
```
fun inputAll (path: string): char array =
  let
    val file = MPL.File.openFile path
    val n = MPL.File.size file
    val result = ForkJoin.alloc n
    val k = 10000 (* block size, for granularity control *)
    val b = 1 + (n-1) div k (* number of blocks *)
  in
    ForkJoin.parfor 1 (0, b) (fn i =>
      let
        val lo = i*k
        val hi = Int.min (lo+k, n)
        val slice = ArraySlice.slice (result, lo, SOME (hi-lo))
      in
        MPL.File.readChars file lo slice
      end);
    MPL.File.closeFile file;
    result
  end
```
Example usage:
```
val fileNames = ["./hello/world", "../../i/hope/you/are", "../having/a/nice/day"]
val contents: char array list = map inputAll fileNames
```