### PR TITLE
MPL.GC structure for mpl-specific gc statistics

### DIFF
--- a/basis-library/build/sources.mlb
+++ b/basis-library/build/sources.mlb
@@ -395,6 +395,8 @@ in
 
    ../mpl/file.sig
    ../mpl/file.sml
+   ../mpl/gc.sig
+   ../mpl/gc.sml
    ../mpl/mpl.sig
    ../mpl/mpl.sml
 

--- a/basis-library/libs/basis-extra/top-level/basis-sigs.sml
+++ b/basis-library/libs/basis-extra/top-level/basis-sigs.sml
@@ -119,3 +119,4 @@ signature UNSAFE = UNSAFE
 
 signature MPL = MPL
 signature MPL_FILE = MPL_FILE
+signature MPL_GC = MPL_GC

--- a/basis-library/mpl.mlb
+++ b/basis-library/mpl.mlb
@@ -14,8 +14,10 @@ in
    local
       libs/basis-extra/basis-extra.mlb
    in
+      signature MPL_GC
       signature MPL_FILE
       signature MPL
+
       structure MPL
    end
 end

--- a/basis-library/mpl/gc.sig
+++ b/basis-library/mpl/gc.sig
@@ -1,0 +1,40 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+signature MPL_GC =
+sig
+  (* An estimate of the current size of the heap. It should be reasonably
+   * accurate, although there could be concurrent allocations and/or
+   * collections happening, so no guarantees.
+   *)
+  val currentHeapSize: unit -> IntInf.int
+
+  (* The following are all cumulative statistics (initially 0, and only
+   * increase throughout execution).
+   *
+   * Each stat comes in two flavors: total, and per-processor. The total
+   * stat is always just a sum of the corresponding per-proc stats.
+   *
+   * Naming convention for `stat` of type `t`:
+   *   val stat: unit -> t
+   *   val statOfProc: int -> t
+   *)
+
+  val bytesAllocated: unit -> IntInf.int
+  val bytesAllocatedOfProc: int -> IntInf.int
+
+  val localBytesReclaimed: unit -> IntInf.int
+  val localBytesReclaimedOfProc: int -> IntInf.int
+
+  val numLocalGCs: unit -> IntInf.int
+  val numLocalGCsOfProc: int -> IntInf.int
+
+  val localGCTime: unit -> Time.time
+  val localGCTimeOfProc: int -> Time.time
+
+  val promoTime: unit -> Time.time
+  val promoTimeOfProc: int -> Time.time
+end

--- a/basis-library/mpl/gc.sml
+++ b/basis-library/mpl/gc.sml
@@ -1,0 +1,94 @@
+(* Copyright (C) 2020 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+structure MPLGC :> MPL_GC =
+struct
+
+  local
+    open Primitive.MLton
+  in
+    val numberOfProcessors = Int32.toInt Parallel.numberOfProcessors
+    val gcState = GCState.gcState
+
+    (* these names got out of hand, huh? *)
+    fun getLocalGCMillisecondsOfProc p =
+      GC.getLocalGCMillisecondsOfProc (gcState (), Word32.fromInt p)
+    fun getPromoMillisecondsOfProc p =
+      GC.getPromoMillisecondsOfProc (gcState (), Word32.fromInt p)
+    fun getCumulativeStatisticsNumLocalGCsOfProc p =
+      GC.getCumulativeStatisticsNumLocalGCsOfProc (gcState (), Word32.fromInt p)
+    fun getCumulativeStatisticsBytesAllocatedOfProc p =
+      GC.getCumulativeStatisticsBytesAllocatedOfProc (gcState (), Word32.fromInt p)
+    fun getCumulativeStatisticsLocalBytesReclaimedOfProc p =
+      GC.getCumulativeStatisticsLocalBytesReclaimedOfProc (gcState (), Word32.fromInt p)
+  end
+
+  exception NotYetImplemented of string
+  exception InvalidProcessorNumber of int
+
+  fun checkProcNum p =
+    if p < 0 orelse p >= numberOfProcessors then
+      raise InvalidProcessorNumber p
+    else
+      ()
+
+  fun millisecondsToTime ms = Time.fromMilliseconds (C_UIntmax.toLargeInt ms)
+
+  fun currentHeapSize () =
+    raise NotYetImplemented "MPL.GC.currentHeapSize"
+
+  fun bytesAllocatedOfProc p =
+    ( checkProcNum p
+    ; C_UIntmax.toLargeInt (getCumulativeStatisticsBytesAllocatedOfProc p)
+    )
+
+  fun localBytesReclaimedOfProc p =
+    ( checkProcNum p
+    ; C_UIntmax.toLargeInt (getCumulativeStatisticsLocalBytesReclaimedOfProc p)
+    )
+
+  fun numLocalGCsOfProc p =
+    ( checkProcNum p
+    ; C_UIntmax.toLargeInt (getCumulativeStatisticsNumLocalGCsOfProc p)
+    )
+
+  fun localGCTimeOfProc p =
+    ( checkProcNum p
+    ; millisecondsToTime (getLocalGCMillisecondsOfProc p)
+    )
+
+  fun promoTimeOfProc p =
+    ( checkProcNum p
+    ; millisecondsToTime (getPromoMillisecondsOfProc p)
+    )
+
+  fun sumAllProcs (f: 'a * 'a -> 'a) (perProc: int -> 'a) =
+    let
+      fun loop b i =
+        if i >= numberOfProcessors then b else loop (f (b, perProc i)) (i+1)
+    in
+      loop (perProc 0) 1
+    end
+
+  fun bytesAllocated () =
+    C_UIntmax.toLargeInt
+    (sumAllProcs C_UIntmax.+ getCumulativeStatisticsBytesAllocatedOfProc)
+
+  fun localBytesReclaimed () =
+    C_UIntmax.toLargeInt
+    (sumAllProcs C_UIntmax.+ getCumulativeStatisticsLocalBytesReclaimedOfProc)
+
+  fun numLocalGCs () =
+    C_UIntmax.toLargeInt
+    (sumAllProcs C_UIntmax.+ getCumulativeStatisticsNumLocalGCsOfProc)
+
+  fun localGCTime () =
+    millisecondsToTime (sumAllProcs C_UIntmax.+ getLocalGCMillisecondsOfProc)
+
+  fun promoTime () =
+    millisecondsToTime (sumAllProcs C_UIntmax.+ getPromoMillisecondsOfProc)
+
+end

--- a/basis-library/mpl/mpl.sig
+++ b/basis-library/mpl/mpl.sig
@@ -7,4 +7,5 @@
 signature MPL =
 sig
   structure File: MPL_FILE
+  structure GC: MPL_GC
 end

--- a/basis-library/mpl/mpl.sml
+++ b/basis-library/mpl/mpl.sml
@@ -7,4 +7,5 @@
 structure MPL :> MPL =
 struct
   structure File = MPLFile
+  structure GC = MPLGC
 end

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -147,8 +147,13 @@ structure GC =
       val setSummary = _import "GC_setControlsSummary" runtime private: GCState.t * bool -> unit;
       val unpack = _import "GC_unpack" runtime private: GCState.t -> unit;
 
+      (* SAM_NOTE: TODO: move these to prim-mpl.sml *)
       val getLocalGCMillisecondsOfProc = _import "GC_getLocalGCMillisecondsOfProc" runtime private : GCState.t * Word32.word -> C_UIntmax.t;
       val getPromoMillisecondsOfProc = _import "GC_getPromoMillisecondsOfProc" runtime private : GCState.t * Word32.word -> C_UIntmax.t;
+      val getCumulativeStatisticsNumLocalGCsOfProc = _import "GC_getCumulativeStatisticsNumLocalGCsOfProc" runtime private : GCState.t * Word32.word -> C_UIntmax.t;
+      val getCumulativeStatisticsBytesAllocatedOfProc = _import "GC_getCumulativeStatisticsBytesAllocatedOfProc" runtime private: GCState.t * Word32.word -> C_UIntmax.t;
+      val getCumulativeStatisticsLocalBytesReclaimedOfProc = _import
+      "GC_getCumulativeStatisticsLocalBytesReclaimedOfProc" runtime private: GCState.t * Word32.word -> C_UIntmax.t;
    end
 
 structure HM =

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -89,6 +89,14 @@ size_t GC_getGlobalCumulativeStatisticsMaxHeapOccupancy (GC_state s) {
   return s->globalCumulativeStatistics->maxHeapOccupancy;
 }
 
+uintmax_t GC_getCumulativeStatisticsBytesAllocatedOfProc(GC_state s, uint32_t proc) {
+  return s->procStates[proc].cumulativeStatistics->bytesAllocated;
+}
+
+uintmax_t GC_getCumulativeStatisticsLocalBytesReclaimedOfProc(GC_state s, uint32_t proc) {
+  return s->procStates[proc].cumulativeStatistics->bytesReclaimedByLocal;
+}
+
 uintmax_t GC_getCumulativeStatisticsBytesAllocated (GC_state s) {
   /* return sum across all processors */
   size_t retVal = 0;
@@ -150,6 +158,10 @@ size_t GC_getCumulativeStatisticsMaxBytesLive (GC_state s) {
   }
 
   return retVal;
+}
+
+uintmax_t GC_getCumulativeStatisticsNumLocalGCsOfProc(GC_state s, uint32_t proc) {
+  return s->procStates[proc].cumulativeStatistics->numHHLocalGCs;
 }
 
 uintmax_t GC_getLocalGCMillisecondsOfProc(GC_state s, uint32_t proc) {

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -121,8 +121,12 @@ PRIVATE size_t GC_getCumulativeStatisticsMaxBytesLive (GC_state s);
 PRIVATE void GC_setHashConsDuringGC (GC_state s, bool b);
 PRIVATE size_t GC_getLastMajorStatisticsBytesLive (GC_state s);
 
+PRIVATE uintmax_t GC_getCumulativeStatisticsBytesAllocatedOfProc(GC_state s, uint32_t proc);
+PRIVATE uintmax_t GC_getCumulativeStatisticsLocalBytesReclaimedOfProc(GC_state s, uint32_t proc);
 PRIVATE uintmax_t GC_getLocalGCMillisecondsOfProc(GC_state s, uint32_t proc);
 PRIVATE uintmax_t GC_getPromoMillisecondsOfProc(GC_state s, uint32_t proc);
+
+PRIVATE uintmax_t GC_getCumulativeStatisticsNumLocalGCsOfProc(GC_state s, uint32_t proc);
 
 PRIVATE pointer GC_getCallFromCHandlerThread (GC_state s);
 PRIVATE void GC_setCallFromCHandlerThreads (GC_state s, pointer p);

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -156,24 +156,21 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
   };
 
   size_t sizesBefore[maxDepth+1];
-  if (LOG_ENABLED(LM_HH_COLLECTION, LL_INFO))
+  for (uint32_t i = 0; i <= maxDepth; i++)
+    sizesBefore[i] = 0;
+  size_t totalSizeBefore = 0;
+  for (HM_HierarchicalHeap cursor = hh;
+       NULL != cursor;
+       cursor = cursor->nextAncestor)
   {
-    for (uint32_t i = 0; i <= maxDepth; i++)
-      sizesBefore[i] = 0;
-
-    for (HM_HierarchicalHeap cursor = hh;
-         NULL != cursor;
-         cursor = cursor->nextAncestor)
-    {
-      uint32_t d = HM_HH_getDepth(cursor);
-      sizesBefore[d] = HM_getChunkListSize(HM_HH_getChunkList(cursor));
-    }
+    uint32_t d = HM_HH_getDepth(cursor);
+    size_t sz = HM_getChunkListSize(HM_HH_getChunkList(cursor));
+    sizesBefore[d] = sz;
+    totalSizeBefore += sz;
   }
 
   Trace0(EVENT_PROMOTION_ENTER);
-  if (needGCTime(s)) {
-    timespec_now(&startTime);
-  }
+  timespec_now(&startTime);
 
   struct HM_chunkList globalDownPtrs;
   HM_initChunkList(&globalDownPtrs);
@@ -182,17 +179,16 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
 
   assertInvariants(thread);
 
-  if (needGCTime(s)) {
-    timespec_now(&stopTime);
-    timespec_sub(&stopTime, &startTime);
-    timespec_add(&(s->cumulativeStatistics->timeLocalPromo), &stopTime);
-  }
+  timespec_now(&stopTime);
+  timespec_sub(&stopTime, &startTime);
+  timespec_add(&(s->cumulativeStatistics->timeLocalPromo), &stopTime);
   Trace0(EVENT_PROMOTION_LEAVE);
 
   if (needGCTime(s)) {
     startTiming (RUSAGE_THREAD, &ru_start);
-    timespec_now(&startTime);
   }
+
+  timespec_now(&startTime);
 
   LOG(LM_HH_COLLECTION, LL_INFO,
       "collecting hh %p (L: %u):\n"
@@ -433,21 +429,23 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
 
   thread->bytesAllocatedSinceLastCollection = 0;
 
-  if (LOG_ENABLED(LM_HH_COLLECTION, LL_INFO))
+  // sizes info and stats
+  size_t totalSizeAfter = 0;
+
+  for (HM_HierarchicalHeap cursor = hh;
+       NULL != cursor;
+       cursor = cursor->nextAncestor)
   {
-    for (HM_HierarchicalHeap cursor = hh;
-         NULL != cursor;
-         cursor = cursor->nextAncestor)
+    uint32_t i = HM_HH_getDepth(cursor);
+
+    HM_chunkList lev = HM_HH_getChunkList(cursor);
+    size_t sizeAfter = HM_getChunkListSize(lev);
+    totalSizeAfter += sizeAfter;
+
+    if (LOG_ENABLED(LM_HH_COLLECTION, LL_INFO) &&
+        (sizesBefore[i] != 0 || sizeAfter != 0))
     {
-      uint32_t i = HM_HH_getDepth(cursor);
       size_t sizeBefore = sizesBefore[i];
-
-      HM_chunkList lev = HM_HH_getChunkList(cursor);
-      size_t sizeAfter = HM_getChunkListSize(lev);
-
-      if (sizeBefore == 0 && sizeAfter == 0)
-        continue;
-
       const char *sign;
       size_t diff;
       if (sizeBefore > sizeAfter) {
@@ -468,21 +466,28 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
     }
   }
 
+  if (totalSizeAfter > totalSizeBefore) {
+    // whoops?
+  } else {
+    s->cumulativeStatistics->bytesReclaimedByLocal +=
+      (totalSizeBefore - totalSizeAfter);
+  }
+
   /* enter statistics if necessary */
+
+  timespec_now(&stopTime);
+  timespec_sub(&stopTime, &startTime);
+  timespec_add(&(s->cumulativeStatistics->timeLocalGC), &stopTime);
+
   if (needGCTime(s)) {
     if (detailedGCTime(s)) {
       stopTiming(RUSAGE_THREAD, &ru_start, &s->cumulativeStatistics->ru_gcHHLocal);
     }
-
     /*
      * RAM_NOTE: small extra here since I recompute delta, but probably not a
      * big deal...
      */
     stopTiming(RUSAGE_THREAD, &ru_start, &s->cumulativeStatistics->ru_gc);
-
-    timespec_now(&stopTime);
-    timespec_sub(&stopTime, &startTime);
-    timespec_add(&(s->cumulativeStatistics->timeLocalGC), &stopTime);
   }
 
   TraceResetCopy();

--- a/runtime/gc/statistics.c
+++ b/runtime/gc/statistics.c
@@ -46,6 +46,7 @@ struct GC_cumulativeStatistics *newCumulativeStatistics(void) {
   cumulativeStatistics->bytesMarkCompacted = 0;
   cumulativeStatistics->bytesScannedMinor = 0;
   cumulativeStatistics->bytesHHLocaled = 0;
+  cumulativeStatistics->bytesReclaimedByLocal = 0;
   cumulativeStatistics->maxBytesLive = 0;
   cumulativeStatistics->maxBytesLiveSinceReset = 0;
   cumulativeStatistics->maxHeapSize = 0;

--- a/runtime/gc/statistics.h
+++ b/runtime/gc/statistics.h
@@ -35,6 +35,7 @@ struct GC_cumulativeStatistics {
   uintmax_t bytesMarkCompacted;
   uintmax_t bytesScannedMinor;
   uintmax_t bytesHHLocaled;
+  uintmax_t bytesReclaimedByLocal;
 
   size_t maxBytesLive;
   size_t maxBytesLiveSinceReset;


### PR DESCRIPTION
This makes some progress on #103 and #106. 

The `MPL.GC` structures includes some statistics, including:
- number of local GCs
- time spent in local GC (wall-clock)
- time spent in promotion before local GC (wall-clock)
- bytes allocated (currently a bit funky, because includes fragmentation due to block allocation strategy)
- bytes reclaimed by local GC (also funky, due to including benefits of defragmentation)

All of these statistics come in both global and per-processor flavors. The global amount is just the sum of per-processor values; it's just for convenience.

There is also a `MPL.GC.currentHeapSize`, but this not implemented yet. I plan to implement this in the future.