### PR TITLE
Put stacks in their own chunks (and cleanup)

### DIFF
--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -479,6 +479,11 @@ size_t HM_getChunkSize(HM_chunk chunk) {
   return chunk->limit - (pointer)chunk;
 }
 
+size_t HM_getChunkSizePastFrontier(HM_chunk chunk) {
+  assert(chunk->frontier < chunk->limit);
+  return (size_t)chunk->limit - (size_t)chunk->frontier;
+}
+
 pointer HM_getChunkStart(HM_chunk chunk) {
   return (pointer)chunk + sizeof(struct HM_chunk) + chunk->startGap;
 }

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -208,6 +208,8 @@ pointer HM_getChunkLimit(HM_chunk chunk);
  */
 size_t HM_getChunkSize(HM_chunk chunk);
 
+size_t HM_getChunkSizePastFrontier(HM_chunk chunk);
+
 /**
  * This function returns the start of allocable area of the chunk (pointer to
  * the first byte that can be allocated), usually used as the initial heap

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -9,27 +9,89 @@
 
 #include "hierarchical-heap.h"
 
+// void growStackCurrent(GC_state s) {
+//   size_t reserved;
+//   GC_stack stack;
+
+//   reserved = sizeofStackGrowReserved(s, getStackCurrent(s));
+//   if (DEBUG_STACKS or s->controls->messages)
+//     fprintf (stderr,
+//              "[GC: Growing stack of size %s bytes to size %s bytes, using %s bytes.]\n",
+//              uintmaxToCommaString(getStackCurrent(s)->reserved),
+//              uintmaxToCommaString(reserved),
+//              uintmaxToCommaString(getStackCurrent(s)->used));
+// #if ASSERT
+//   assert(threadAndHeapOkay(s));
+//   GC_thread thread = getThreadCurrent(s);
+//   assert(s->frontier == HM_HH_getFrontier(thread));
+//   assert((size_t)(HM_HH_getLimit(thread) - HM_HH_getFrontier(thread))
+//          >= sizeofStackWithMetaData(s, reserved));
+// #endif
+//   stack = newStack(s, reserved);
+//   copyStack(s, getStackCurrent(s), stack);
+//   getThreadCurrent(s)->stack = pointerToObjptr ((pointer)stack, NULL);
+// }
+
 void growStackCurrent(GC_state s) {
   size_t reserved;
+  size_t stackSize;
   GC_stack stack;
 
   reserved = sizeofStackGrowReserved(s, getStackCurrent(s));
+  assert(isStackReservedAligned (s, reserved));
+  stackSize = sizeofStackWithMetaData(s, reserved);
   if (DEBUG_STACKS or s->controls->messages)
     fprintf (stderr,
              "[GC: Growing stack of size %s bytes to size %s bytes, using %s bytes.]\n",
              uintmaxToCommaString(getStackCurrent(s)->reserved),
              uintmaxToCommaString(reserved),
              uintmaxToCommaString(getStackCurrent(s)->used));
-#if ASSERT
-  assert(threadAndHeapOkay(s));
-  GC_thread thread = getThreadCurrent(s);
-  assert(s->frontier == HM_HH_getFrontier(thread));
-  assert((size_t)(HM_HH_getLimit(thread) - HM_HH_getFrontier(thread))
-         >= sizeofStackWithMetaData(s, reserved));
-#endif
-  stack = newStack(s, reserved);
+  if (reserved > s->cumulativeStatistics->maxStackSize)
+    s->cumulativeStatistics->maxStackSize = reserved;
+
+  HM_chunk chunk = HM_getChunkOf((pointer)getStackCurrent(s));
+  HM_HierarchicalHeap hh = HM_getLevelHeadPathCompress(chunk);
+
+  if (chunk->mightContainMultipleObjects) {
+    DIE("Tried to grow a stack without its own chunk.");
+  }
+
+  assert(HM_getChunkFrontier(chunk) == HM_getChunkStart(chunk) +
+    sizeofStackWithMetaData(s, getStackCurrent(s)->reserved));
+
+  /* the easy case: plenty of space in the stack's chunk to just grow the
+   * stack in place. */
+  if (stackSize <= (size_t)(HM_getChunkLimit(chunk) - HM_getChunkStart(chunk))) {
+    getStackCurrent(s)->reserved = reserved;
+    HM_updateChunkValues(chunk, HM_getChunkStart(chunk) + stackSize);
+    return;
+  }
+
+  /* in this case, the new stack needs more space, so allocate a new chunk,
+   * copy the stack, and throw away the old chunk. */
+  HM_chunk newChunk = HM_allocateChunk(HM_HH_getChunkList(hh), stackSize);
+  if (NULL == newChunk) {
+    DIE("Ran out of space to grow stack!");
+  }
+  assert(stackSize < HM_getChunkSizePastFrontier(newChunk));
+  newChunk->mightContainMultipleObjects = FALSE;
+  newChunk->levelHead = hh;
+
+  pointer frontier = HM_getChunkFrontier(newChunk);
+  assert(frontier == HM_getChunkStart(newChunk));
+  assert(GC_STACK_METADATA_SIZE == GC_HEADER_SIZE);
+  *((GC_header*)frontier) = GC_STACK_HEADER;
+  stack = (GC_stack)(frontier + GC_HEADER_SIZE);
+  stack->reserved = reserved;
+  stack->used = 0;
+  HM_updateChunkValues(newChunk, frontier + stackSize);
+
   copyStack(s, getStackCurrent(s), stack);
-  getThreadCurrent(s)->stack = pointerToObjptr ((pointer)stack, NULL);
+  getThreadCurrent(s)->stack = pointerToObjptr((pointer)stack, NULL);
+
+  assert(getThreadCurrent(s)->currentChunk != chunk);
+  HM_unlinkChunk(HM_HH_getChunkList(hh), chunk);
+  HM_appendChunk(getFreeListSmall(s), chunk);
 }
 
 void GC_collect (GC_state s, size_t bytesRequested, bool force) {

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2009-2010,2012,2016 Matthew Fluet.
+/* Copyright (C) 2020 Sam Westrick.
+ * Copyright (C) 2009-2010,2012,2016 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -8,29 +9,6 @@
  */
 
 #include "hierarchical-heap.h"
-
-// void growStackCurrent(GC_state s) {
-//   size_t reserved;
-//   GC_stack stack;
-
-//   reserved = sizeofStackGrowReserved(s, getStackCurrent(s));
-//   if (DEBUG_STACKS or s->controls->messages)
-//     fprintf (stderr,
-//              "[GC: Growing stack of size %s bytes to size %s bytes, using %s bytes.]\n",
-//              uintmaxToCommaString(getStackCurrent(s)->reserved),
-//              uintmaxToCommaString(reserved),
-//              uintmaxToCommaString(getStackCurrent(s)->used));
-// #if ASSERT
-//   assert(threadAndHeapOkay(s));
-//   GC_thread thread = getThreadCurrent(s);
-//   assert(s->frontier == HM_HH_getFrontier(thread));
-//   assert((size_t)(HM_HH_getLimit(thread) - HM_HH_getFrontier(thread))
-//          >= sizeofStackWithMetaData(s, reserved));
-// #endif
-//   stack = newStack(s, reserved);
-//   copyStack(s, getStackCurrent(s), stack);
-//   getThreadCurrent(s)->stack = pointerToObjptr ((pointer)stack, NULL);
-// }
 
 void growStackCurrent(GC_state s) {
   size_t reserved;

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -313,7 +313,9 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
         toSpaceList->firstChunk,
         HM_getChunkStart(toSpaceList->firstChunk),
         &skipStackAndThreadObjptrPredicate,
+        // trueObjptrPredicate,
         &ssatoPredicateArgs,
+        // NULL,
         &forwardHHObjptr,
         &forwardHHObjptrArgs);
     }
@@ -819,6 +821,12 @@ GC_objectTypeTag computeObjectCopyParameters(GC_state s, pointer p,
       *metaDataSize = GC_STACK_METADATA_SIZE;
       stack = (GC_stack)p;
 
+      /* SAM_NOTE:
+       * I am disabling shrinking here because it assumes that
+       * the stack is going to be copied, which doesn't work with the
+       * "stacks-in-their-own-chunks" strategy.
+       */
+#if 0
       /* RAM_NOTE: This changes with non-local collection */
       /* Check if the pointer is the current stack of my processor. */
       current = getStackCurrent(s) == stack;
@@ -833,6 +841,7 @@ GC_objectTypeTag computeObjectCopyParameters(GC_state s, pointer p,
             uintmaxToCommaString(stack->used));
         stack->reserved = reservedNew;
       }
+#endif
       *objectSize = sizeof (struct GC_stack) + stack->reserved;
       *copySize = sizeof (struct GC_stack) + stack->used;
     }

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2019 Sam Westrick
+/* Copyright (C) 2018-2020 Sam Westrick
  * Copyright (C) 2015 Ram Raghunathan.
  *
  * MLton is released under a HPND-style license.
@@ -67,8 +67,8 @@ bool skipStackAndThreadObjptrPredicate(GC_state s,
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
-  GC_state s = pthread_getspecific (gcstate_key);
+void HM_HHC_collectLocal(uint32_t desiredScope) {
+  GC_state s = pthread_getspecific(gcstate_key);
   GC_thread thread = getThreadCurrent(s);
   struct HM_HierarchicalHeap* hh = thread->hierarchicalHeap;
 
@@ -87,11 +87,6 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
     return;
   }
 
-  // if (!force && thread->currentDepth <= 1) {
-  //   LOG(LM_HH_COLLECTION, LL_INFO, "Skipping collection during sequential section");
-  //   return;
-  // }
-
   uint64_t topval = *(uint64_t*)objptrToPointer(s->wsQueueTop, NULL);
   uint32_t potentialLocalScope = UNPACK_IDX(topval);
 
@@ -106,7 +101,6 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
 
   if (minDepth == 0) {
     LOG(LM_HH_COLLECTION, LL_INFO, "Skipping collection that includes root heap");
-    // goto unlock_local_scope_and_return;
     releaseLocalScope(s, originalLocalScope);
     return;
   }
@@ -116,7 +110,6 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
         "Skipping collection because minDepth > current depth (%u > %u)",
         minDepth,
         thread->currentDepth);
-    // goto unlock_local_scope_and_return;
     releaseLocalScope(s, originalLocalScope);
     return;
   }
@@ -313,9 +306,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
         toSpaceList->firstChunk,
         HM_getChunkStart(toSpaceList->firstChunk),
         &skipStackAndThreadObjptrPredicate,
-        // trueObjptrPredicate,
         &ssatoPredicateArgs,
-        // NULL,
         &forwardHHObjptr,
         &forwardHHObjptrArgs);
     }
@@ -498,7 +489,6 @@ void HM_HHC_collectLocal(uint32_t desiredScope, bool force) {
   LOG(LM_HH_COLLECTION, LL_DEBUG,
       "END");
 
-// unlock_local_scope_and_return:
   releaseLocalScope(s, originalLocalScope);
   return;
 }
@@ -813,8 +803,8 @@ GC_objectTypeTag computeObjectCopyParameters(GC_state s, pointer p,
       *copySize = *objectSize;
     } else {
       /* Stack. */
-      bool current;
-      size_t reservedNew;
+      // bool current;
+      // size_t reservedNew;
       GC_stack stack;
 
       assert (STACK_TAG == tag);

--- a/runtime/gc/hierarchical-heap-collection.h
+++ b/runtime/gc/hierarchical-heap-collection.h
@@ -50,7 +50,7 @@ struct ForwardHHObjptrArgs {
 /**
  * This function performs a local collection on the current hierarchical heap
  */
-void HM_HHC_collectLocal(uint32_t desiredScope, bool force);
+void HM_HHC_collectLocal(uint32_t desiredScope);
 
 /**
  * Forwards the object pointed to by 'opp' into 'destinationLevelList' starting

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2012,2014,2016 Matthew Fluet.
+/* Copyright (C) 2020 Sam Westrick.
+ * Copyright (C) 2011-2012,2014,2016 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -40,7 +41,6 @@ void initVectors(GC_state s, GC_thread thread) {
 
   currentChunk = HM_getChunkOf(frontier);
   assert(currentChunk == thread->currentChunk);
-  // assert(currentChunk == HM_getChunkListLastChunk(HM_HH_getChunkList(thread->hierarchicalHeap)));
   assert(0 == thread->currentDepth);
 
   for (i = 0; i < s->vectorInitsLength; i++) {
@@ -77,7 +77,6 @@ void initVectors(GC_state s, GC_thread thread) {
 
       currentChunk = HM_getChunkOf(frontier);
       assert(currentChunk == thread->currentChunk);
-      // assert(currentChunk == HM_getChunkListLastChunk(HM_HH_getChunkList(thread->hierarchicalHeap)));
     }
 
     assert(isFrontierAligned(s, frontier));
@@ -136,7 +135,6 @@ void initVectors(GC_state s, GC_thread thread) {
 
     currentChunk = HM_getChunkOf(frontier);
     assert(currentChunk == thread->currentChunk);
-    // assert(currentChunk == HM_getChunkListLastChunk(HM_HH_getChunkList(thread->hierarchicalHeap)));
   }
 
   assert(isFrontierAligned(s, s->frontier));
@@ -153,7 +151,6 @@ GC_thread initThreadAndHeap(GC_state s, uint32_t depth) {
 #if ASSERT
   HM_chunk current = HM_getChunkOf(s->frontier);
   assert(HM_HH_getDepth(thread->hierarchicalHeap) == depth);
-  // assert(current == HM_getChunkListLastChunk(HM_HH_getChunkList(thread->hierarchicalHeap)));
   assert(current == thread->currentChunk);
   assert(current->mightContainMultipleObjects);
   assert(inFirstBlockOfChunk(current, s->frontier));
@@ -189,7 +186,6 @@ void initWorld(GC_state s) {
   HM_chunk current = HM_getChunkOf(s->frontier);
   assert(HM_HH_getDepth(hh) == 0);
   assert(current == thread->currentChunk);
-  // assert(current == HM_getChunkListLastChunk(HM_HH_getChunkList(hh)));
   assert(current->mightContainMultipleObjects);
   assert(inFirstBlockOfChunk(current, s->frontier));
   assert(s->frontier >= HM_getChunkFrontier(current));
@@ -201,9 +197,6 @@ void initWorld(GC_state s) {
 void duplicateWorld (GC_state d, GC_state s) {
   d->lastMajorStatistics->bytesLive = 0;
 
-  /* SAM_NOTE: TODO:
-   * initWorld calls switchToThread, but duplicateWorld does not. Why?
-   * Is this safe? */
   initThreadAndHeap(d, 0);
 
   /* Now copy stats, heap data from original */

--- a/runtime/gc/invariant.c
+++ b/runtime/gc/invariant.c
@@ -16,7 +16,8 @@ bool invariantForGC(__attribute__((unused)) GC_state s) {
 
 bool invariantForMutatorFrontier (GC_state s) {
   GC_thread thread = getThreadCurrent(s);
-  return (thread->bytesNeeded <= (size_t)(s->limitPlusSlop - s->frontier));
+  return (thread->bytesNeeded <= (size_t)(s->limitPlusSlop - s->frontier))
+      && (TRUE == HM_getChunkOf(s->frontier)->mightContainMultipleObjects);
 }
 
 #if ASSERT
@@ -31,7 +32,8 @@ bool strongInvariantForMutatorFrontier (GC_state s) {
 bool invariantForMutatorStack (GC_state s) {
   GC_stack stack = getStackCurrent(s);
   return (getStackTop (s, stack)
-          <= getStackLimit (s, stack) + getStackTopFrameSize (s, stack));
+          <= getStackLimit (s, stack) + getStackTopFrameSize (s, stack))
+      && (FALSE == HM_getChunkOf((pointer)stack)->mightContainMultipleObjects);
 }
 
 #if ASSERT

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -126,11 +126,11 @@ void GC_HH_moveNewThreadToDepth(pointer threadp, uint32_t depth) {
    * checks are good enough for now... */
   assert(hh != NULL);
   assert(HM_HH_getDepth(hh) == 0);
-  assert(HM_getChunkListFirstChunk(HM_HH_getChunkList(hh)) ==
+  assert(HM_getChunkListFirstChunk(HM_HH_getChunkList(hh))->nextChunk ==
          HM_getChunkListLastChunk(HM_HH_getChunkList(hh)));
   assert(HM_getChunkOf(threadp) == HM_getChunkListFirstChunk(HM_HH_getChunkList(hh)));
   assert(HM_getChunkOf(objptrToPointer(thread->stack, NULL)) ==
-         HM_getChunkListFirstChunk(HM_HH_getChunkList(hh)));
+         HM_getChunkListLastChunk(HM_HH_getChunkList(hh)));
 
   thread->currentDepth = depth;
   hh->depth = depth;


### PR DESCRIPTION
This patch gives each stack its own chunk, similar to large arrays. Some advantages:
- Stacks can be resized in-place (if the chunk is large enough) without copying any data.
- When a stack needs to be resized larger than its current chunk, we can copy it to a new chunk and immediately reclaim the old chunk.
- During GC, stack chunks can be relocated to the to-space without any copying.
- We should no longer see the strange behavior of stacks "moving around" when they are resized. (Previously, resizing a stack allocated a new stack at the current frontier, which could be deeper than the original location of the stack.)

I did some quick tests and found that these changes are sometimes significant, e.g. in a stack-stress benchmark like `fib` I saw 20% improvement in space on 70 cores. Elsewhere, I don't think this change affects time or space too much.

To implement this change, I disabled stack shrinking at local GCs. Perhaps this can be re-enabled in the future, but it doesn't seem outrageously important, since the threading in MPL is so well disciplined.