### PR TITLE
New example: audio reverb effect on .wav files

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,7 +11,8 @@ PROGRAMS= \
 	tokens \
 	nn \
 	dedup \
-	nqueens
+	nqueens \
+	reverb
 
 all: $(PROGRAMS)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,3 +108,12 @@ $ make nn
 $ bin/nn @mpl procs 4 -- -N 10000 -output result.ppm -resolution 1000
 ```
 
+## Reverb
+
+Applies an artificial reverberation effect to a `.wav` sound file. At the
+moment, it only supports either 8-bit or 16-bit PCM, and if there
+are multiple channels, these will be mixed into a mono-channel output.
+```
+$ make reverb
+$ bin/reverb @mpl procs 4 -- INPUT.wav -output OUTPUT.wav
+```

--- a/examples/lib/NewWaveIO.sml
+++ b/examples/lib/NewWaveIO.sml
@@ -1,0 +1,332 @@
+structure NewWaveIO:
+sig
+  (* A sound is a sequence of samples at the given
+   * sample rate, sr (measured in Hz).
+   * Each sample is in range [-1.0, +1.0]. *)
+  type sound = {sr: int, data: real Seq.t}
+
+  val readSound: string -> sound
+  val writeSound: sound -> string -> unit
+
+  (* Essentially mu-law compression. Normalizes to [-1,+1] and compresses
+   * the dynamic range slightly. The boost parameter should be >= 1. *)
+  val compress: real -> sound -> sound
+end =
+struct
+
+  type sound = {sr: int, data: real Seq.t}
+
+  structure AS = ArraySlice
+
+  fun err msg =
+    raise Fail ("NewWaveIO: " ^ msg)
+
+  fun compress boost (snd as {sr, data}: sound) =
+    if boost < 1.0 then
+      err "Compression boost parameter must be at least 1"
+    else
+      let
+        (* maximum amplitude *)
+        val maxA =
+          SeqBasis.reduce 10000 Real.max 1.0 (0, Seq.length data)
+            (fn i => Real.abs (Seq.nth data i))
+
+        (* a little buffer of intensity to avoid distortion *)
+        val maxA' = 1.05 * maxA
+
+        val scale = Math.ln (1.0 + boost)
+
+        fun transfer x =
+          let
+            (* normalized *)
+            val x' = Real.abs (x / maxA')
+          in
+            (* compressed *)
+            Real.copySign (Math.ln (1.0 + boost * x') / scale, x)
+          end
+      in
+        { sr = sr
+        , data = Seq.map transfer data
+        }
+      end
+
+  fun readSound path =
+    let
+      val bytes = ReadFile.contentsBinSeq path
+
+      fun findChunk chunkId offset =
+        if offset > (Seq.length bytes - 8) then
+          err "unexpected end of file"
+        else if Parse.r32b bytes offset = chunkId then
+          offset (* found it! *)
+        else
+          let
+            val chunkSize = Word32.toInt (Parse.r32l bytes (offset+4))
+            val chunkName =
+              CharVector.tabulate (4, fn i =>
+                Char.chr (Word8.toInt (Seq.nth bytes (offset+i))))
+          in
+            if chunkSize < 0 then
+              err ("error parsing chunk size of '" ^ chunkName ^ "' chunk")
+            else
+              findChunk chunkId (offset + 8 + chunkSize)
+          end
+
+      (* =======================================================
+       * RIFF header, 12 bytes
+       *)
+
+      val _ =
+        if Seq.length bytes >= 12 then ()
+        else err "not enough bytes for RIFF header"
+
+      val offset = 0
+      val riff = 0wx52494646 (* ascii "RIFF", big endian *)
+      val _ =
+        if Parse.r32b bytes offset = riff then ()
+        else err "expected 'RIFF' chunk ID"
+
+      (* the chunkSize should be the size of the "rest of the file" *)
+      val offset = 4
+      val chunkSize = Word32.toInt (Parse.r32l bytes offset)
+
+      val totalFileSize = 8 + chunkSize
+      val _ =
+        if Seq.length bytes >= totalFileSize then ()
+        else err ("expected " ^ Int.toString totalFileSize ^
+                  " bytes but the file is only " ^
+                  Int.toString (Seq.length bytes))
+
+      val offset = 8
+      val wave = 0wx57415645 (* ascii "WAVE" big endian *)
+      val _ =
+        if Parse.r32b bytes offset = wave then ()
+        else err "expected 'WAVE' format"
+
+      val offset = 12
+
+      (* =======================================================
+       * fmt subchunk, should be at least 8+16 bytes total for PCM
+       *)
+
+      val fmtId = 0wx666d7420 (* ascii "fmt " big endian *)
+      val fmtChunkStart = findChunk fmtId offset
+      val offset = fmtChunkStart
+
+      val _ =
+        if Parse.r32b bytes offset = fmtId then ()
+        else err "expected 'fmt ' chunk ID"
+
+      val offset = offset+4
+      val fmtChunkSize = Word32.toInt (Parse.r32l bytes offset)
+      val _ =
+        if fmtChunkSize >= 16 then ()
+        else err "expected 'fmt ' chunk to be at least 16 bytes"
+
+      val offset = offset+4
+      val audioFormat = Word16.toInt (Parse.r16l bytes offset)
+      val _ =
+        if audioFormat = 1 then ()
+        else err ("expected PCM audio format, but found 0x"
+                  ^ Int.fmt StringCvt.HEX audioFormat)
+
+      val offset = offset+2
+      val numChannels = Word16.toInt (Parse.r16l bytes offset)
+
+      val offset = offset+2
+      val sampleRate = Word32.toInt (Parse.r32l bytes offset)
+
+      val offset = offset+4
+      val byteRate = Word32.toInt (Parse.r32l bytes offset)
+
+      val offset = offset+4
+      val blockAlign = Word16.toInt (Parse.r16l bytes offset)
+
+      val offset = offset+2
+      val bitsPerSample = Word16.toInt (Parse.r16l bytes offset)
+      val bytesPerSample = bitsPerSample div 8
+
+      val offset = fmtChunkStart+8+fmtChunkSize
+
+      (* =======================================================
+       * data subchunk, should be the rest of the file
+       *)
+
+      val dataId = 0wx64617461 (* ascii "data" big endian *)
+      val dataChunkStart = findChunk dataId offset
+      val offset = dataChunkStart
+
+      val _ =
+        if Parse.r32b bytes offset = dataId then ()
+        else err "expected 'data' chunk ID"
+
+      val offset = offset + 4
+      val dataSize = Word32.toInt (Parse.r32l bytes offset)
+      val _ =
+        if dataChunkStart + 8 + dataSize <= totalFileSize then ()
+        else err ("badly formatted data chunk: unexpected end-of-file")
+
+      val dataStart = dataChunkStart + 8
+
+      val numSamples = (dataSize div numChannels) div bytesPerSample
+
+      fun readSample8 pos =
+        Real.fromInt (Word8.toInt (Seq.nth bytes pos) - 128) / 256.0
+      fun readSample16 pos =
+        Real.fromInt (Word16.toIntX (Parse.r16l bytes pos)) / 32768.0
+
+      val readSample =
+        case bytesPerSample of
+          1 => readSample8
+        | 2 => readSample16
+        | _ => err "only 8-bit and 16-bit samples supported at the moment"
+
+      (* jth sample of ith channel *)
+      fun readChannel i j =
+        readSample (dataStart + j * (numChannels * bytesPerSample)
+                              + i * bytesPerSample)
+
+      val rawData =
+        AS.full (SeqBasis.tabulate 1000 (0, numSamples) (fn j =>
+            Util.loop (0, numChannels) 0.0 (fn (s, i) => s + readChannel i j)))
+
+      val rawResult = {sr = sampleRate, data = rawData}
+    in
+      if numChannels = 1 then
+        rawResult
+      else
+        ( TextIO.output (TextIO.stdErr,
+            "[WARN] mixing " ^ Int.toString numChannels
+            ^ " channels down to mono\n")
+        ; compress 1.0 rawResult
+        )
+    end
+
+  (* =======================================================================
+   * some utilities for writing
+   *)
+
+  fun w8 file (w: Word8.word) = BinIO.output1 (file, w)
+
+  fun w64b file (w: Word64.word) =
+    let
+      val w8 = w8 file
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w56));
+      w8 (Word8.fromLarge (w >> 0w48));
+      w8 (Word8.fromLarge (w >> 0w40));
+      w8 (Word8.fromLarge (w >> 0w32));
+      w8 (Word8.fromLarge (w >> 0w24));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w32b file (w: Word32.word) =
+    let
+      val w8 = w8 file
+      val w = Word32.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w24));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w32l file (w: Word32.word) =
+    let
+      val w8 = w8 file
+      val w = Word32.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge w);
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w24))
+    end
+
+  fun w16b file (w: Word16.word) =
+    let
+      val w8 = w8 file
+      val w = Word16.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w16l file (w: Word16.word) =
+    let
+      val w8 = w8 file
+      val w = Word16.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge w);
+      w8 (Word8.fromLarge (w >> 0w8))
+    end
+
+  (* ====================================================================== *)
+
+  fun writeSound ({sr, data}: sound) path =
+    let
+      val srw = Word32.fromInt sr
+
+      val file = BinIO.openOut path
+
+      val w32b = w32b file
+      val w32l = w32l file
+      val w16l = w16l file
+
+      val totalBytes =
+        44 + (Seq.length data * 2)
+
+      val riffId = 0wx52494646 (* ascii "RIFF", big endian *)
+      val fmtId = 0wx666d7420 (* ascii "fmt " big endian *)
+      val wave = 0wx57415645 (* ascii "WAVE" big endian *)
+      val dataId = 0wx64617461 (* ascii "data" big endian *)
+    in
+      (* ============================
+       * RIFF header, 12 bytes *)
+      w32b riffId;
+      w32l (Word32.fromInt (totalBytes - 8));
+      w32b wave;
+
+      (* ============================
+       * fmt subchunk, 24 bytes *)
+      w32b fmtId;
+      w32l 0w16;    (* 16 remaining bytes in subchunk *)
+      w16l 0w1;     (* audio format PCM = 1 *)
+      w16l 0w1;     (* 1 channel (mono) *)
+      w32l srw;     (* sample rate *)
+      w32l (srw * 0w2); (* "byte rate" = sampleRate * numChannels * bytesPerSample *)
+      w16l 0w2;     (* "block align" = numChannels * bytesPerSample *)
+      w16l 0w16;    (* bits per sample *)
+
+      (* ============================
+       * data subchunk: rest of file *)
+      w32b dataId;
+      w32l (Word32.fromInt (2 * Seq.length data)); (* number of data bytes *)
+
+      Util.for (0, Seq.length data) (fn i =>
+        let
+          val s = Seq.nth data i
+          val s =
+            if s < ~1.0 then ~1.0
+            else if s > 1.0 then 1.0
+            else s
+          val s = Real.round (s * 32767.0)
+          val s = if s < 0 then s + 65536 else s
+        in
+          w16l (Word16.fromInt s)
+        end);
+
+      BinIO.closeOut file
+    end
+end

--- a/examples/lib/Parse.sml
+++ b/examples/lib/Parse.sml
@@ -1,0 +1,179 @@
+structure Parse =
+struct
+
+  fun parseDigit char =
+    let
+      val code = Char.ord char
+      val code0 = Char.ord #"0"
+      val code9 = Char.ord #"9"
+    in
+      if code < code0 orelse code9 < code then
+        NONE
+      else
+        SOME (code - code0)
+    end
+
+  fun parseInt s =
+    let
+      val n = Seq.length s
+      fun c i = Seq.nth s i
+
+      fun build x i =
+        if i >= n then SOME x else
+        case c i of
+          #"," => build x (i+1)
+        | #"_" => build x (i+1)
+        | cc =>
+            case parseDigit cc of
+              NONE => NONE
+            | SOME dig => build (x * 10 + dig) (i+1)
+    in
+      if n = 0 then NONE
+      else if (c 0 = #"-" orelse c 0 = #"~") then
+        Option.map (fn x => x * ~1) (build 0 1)
+      else if (c 0 = #"+") then
+        build 0 1
+      else
+        build 0 0
+    end
+
+  fun parseReal s =
+    let
+      val n = Seq.length s
+      fun c i = Seq.nth s i
+
+      fun buildAfterE x i =
+        Option.map (fn e => x * Math.pow (10.0, Real.fromInt e))
+          (parseInt (Seq.subseq s (i, n-i)))
+
+      fun buildAfterPoint m x i =
+        if i >= n then SOME x else
+        case c i of
+          #"," => buildAfterPoint m x (i+1)
+        | #"_" => buildAfterPoint m x (i+1)
+        | #"." => NONE
+        | #"e" => buildAfterE x (i+1)
+        | #"E" => buildAfterE x (i+1)
+        | cc =>
+            case parseDigit cc of
+              NONE => NONE
+            | SOME dig => buildAfterPoint (m * 0.1) (x + m * (Real.fromInt dig)) (i+1)
+
+      fun buildBeforePoint x i =
+        if i >= n then SOME x else
+        case c i of
+          #"," => buildBeforePoint x (i+1)
+        | #"_" => buildBeforePoint x (i+1)
+        | #"." => buildAfterPoint 0.1 x (i+1)
+        | #"e" => buildAfterE x (i+1)
+        | #"E" => buildAfterE x (i+1)
+        | cc =>
+            case parseDigit cc of
+              NONE => NONE
+            | SOME dig => buildBeforePoint (x * 10.0 + Real.fromInt dig) (i+1)
+    in
+      if n = 0 then NONE
+      else if (c 0 = #"-" orelse c 0 = #"~") then
+        Option.map (fn x => x * ~1.0) (buildBeforePoint 0.0 1)
+      else
+        buildBeforePoint 0.0 0
+    end
+
+  fun parseString s =
+    CharVector.tabulate (Seq.length s, Seq.nth s)
+
+  (* read a Word16, big endian, starting at index i *)
+  fun r16b bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes i)
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+1)))
+    in
+      Word16.fromLarge w
+    end
+
+  (* read a Word32, big endian, starting at index i *)
+  fun r32b bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes i)
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+1)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+2)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+3)))
+    in
+      Word32.fromLarge w
+    end
+
+  (* read a Word64, big endian, starting at index i *)
+  fun r64b bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes i)
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+1)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+2)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+3)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+4)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+5)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+6)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+7)))
+    in
+      w
+    end
+
+  (* read a Word16, little endian, starting at index i *)
+  fun r16l bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes (i+1))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes i))
+    in
+      Word16.fromLarge w
+    end
+
+  (* read a Word32, little endian, starting at index i *)
+  fun r32l bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes (i+3))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+2)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+1)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes i))
+    in
+      Word32.fromLarge w
+    end
+
+  (* read a Word64, little endian, starting at index i *)
+  fun r64l bytes i =
+    let
+      infix 2 << orb
+      val op<< = Word64.<<
+      val op orb = Word64.orb
+
+      val w = Word8.toLarge (Seq.nth bytes (i+7))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+6)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+5)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+4)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+3)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+2)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes (i+1)))
+      val w = (w << 0w8) orb (Word8.toLarge (Seq.nth bytes i))
+    in
+      w
+    end
+
+end

--- a/examples/lib/ReadFile.sml
+++ b/examples/lib/ReadFile.sml
@@ -2,44 +2,41 @@ structure ReadFile:
 sig
   val contents: string -> string
   val contentsSeq: string -> char Seq.t
+  val contentsBinSeq: string -> Word8.word Seq.t
 end =
 struct
 
-  type 'a seq = 'a Seq.t
+  fun contentsSeq' reader filename =
+    let
+      val file = MPL.File.openFile filename
+      val n = MPL.File.size file
+      val arr = ForkJoin.alloc n
+      val k = 10000
+      val m = 1 + (n-1) div k
+    in
+      ForkJoin.parfor 1 (0, m) (fn i =>
+        let
+          val lo = i*k
+          val hi = Int.min ((i+1)*k, n)
+        in
+          reader file lo (ArraySlice.slice (arr, lo, SOME (hi-lo)))
+        end);
+      MPL.File.closeFile file;
+      ArraySlice.full arr
+    end
 
   fun contentsSeq filename =
-    let
-      val inStream = TextIO.openIn filename
-      fun loop () =
-        let
-          val str = TextIO.inputN (inStream, 100000)
-        in
-          if String.size str = 0 then []
-          else str :: loop ()
-        end
-      val blocks = ArraySlice.full (Array.fromList (loop ()))
-      val numBlocks = Seq.length blocks
-      fun blockLen i = Vector.length (Seq.nth blocks i)
-      val starts = ArraySlice.full
-        (SeqBasis.scan 10000 op+ 0 (0, numBlocks) blockLen)
-      val total = Seq.nth starts numBlocks
-      val r = ForkJoin.alloc total
-      fun writeBlock i =
-        let
-           val start = Seq.nth starts i
-           val block = Seq.nth blocks i
-        in
-          Vector.appi (fn (j, x) => Array.update (r, start + j, x)) block
-        end
-      val _ = ForkJoin.parfor 1 (0, numBlocks) writeBlock
-    in
-      ArraySlice.full r
-    end
+    contentsSeq' MPL.File.readChars filename
+
+  fun contentsBinSeq filename =
+    contentsSeq' MPL.File.readWord8s filename
 
   fun contents filename =
     let
-      val charArr = contentsSeq filename
+      val chars = contentsSeq filename
     in
-      CharVector.tabulate (Seq.length charArr, Seq.nth charArr)
+      CharVector.tabulate (ArraySlice.length chars,
+        fn i => ArraySlice.sub (chars, i))
     end
+
 end

--- a/examples/lib/Signal.sml
+++ b/examples/lib/Signal.sml
@@ -1,0 +1,196 @@
+structure Signal:
+sig
+  type sound = NewWaveIO.sound
+  val delay: real -> real -> sound -> sound
+  val allPass: real -> real -> sound -> sound
+  val reverb: sound -> sound
+end =
+struct
+
+  type sound = NewWaveIO.sound
+
+  structure A = Array
+  structure AS = ArraySlice
+
+  (* ds: the delay distance, in seconds
+   * a: the decay parameter in range [0,1]
+   * snd: sequence of samples in range [-1,1]
+   *)
+  fun delay ds a (snd as {sr, data}: sound) =
+    let
+      val N = Seq.length data
+
+      (* convert to samples *)
+      val ds = Real.round (ds * Real.fromInt sr)
+
+      (* i: skip distance
+       * s: current sound
+       * powa: a^i
+       *
+       * Each loop iteration adds `a^i * s[k]` to `s[k+i*ds]` for each k.
+       * we compute this by "pulling" `a^i * s[j-i*ds]` into each s[j].
+       * This can either be done in two ways:
+       *   1. Copy the entire sound and recompute each s[j]
+       *   2. Modify only the s[j]'s which need to be recomputed. Note that
+       *   all samples before index i*ds do not change.
+       *
+       * Approach 1 performs exactly N writes, whereas approach 2 performs
+       * approximately 2*(N-i*ds) writes (because it writes intermediate results
+       * into a temporary array and then copies back into s). So, for earlier
+       * iterations (when i*ds is small) it makes sense to prefer the former.
+       * Then when i*ds is large enough, we switch to the latter approach.
+       * This guarantees O(N) work in total, because i increases exponentially.
+       *
+       * We're done when the skip distance i*ds exceeds the number of samples,
+       * or when a^i is sufficiently small (at which point further contributions
+       * would not be audible).
+       *)
+
+      fun next s powa i j =
+        let val k = j - (i*ds)
+        in (Seq.nth s j) + (if k < 0 then 0.0 else powa * Seq.nth s k)
+        end
+
+      fun loop s powa i =
+        if i*ds >= N orelse powa < 0.0001 then
+          s
+        else if i*ds < N div 10 then
+          loop (Seq.tabulate (next s powa i) N) (powa*powa) (2*i)
+        else
+          let
+            val tmp = SeqBasis.tabulate 10000 (i*ds, N) (next s powa i)
+          in
+            ForkJoin.parfor 10000 (i*ds, N) (fn j =>
+              AS.update (s, j, A.sub (tmp, j - i*ds)));
+
+            loop s (powa*powa) (2*i)
+          end
+
+      (* It's not correct to just call `loop data a 1`, because this could
+       * modify the input `data`. We need to make sure that we are operating
+       * on a copy. So, we'll open up the first iteration of the loop.
+       *)
+      val result =
+        if ds >= N orelse a < 0.0001 then
+          data
+        else
+          loop (Seq.tabulate (next data a 1) N) (a*a) 2
+    in
+      {sr = sr, data = result}
+    end
+
+  fun allPass ds a (snd as {sr, data}: sound) =
+    let
+      val {data=combed, ...} = delay ds a snd
+
+      (* convert to samples *)
+      val ds = Real.round (ds * Real.fromInt sr)
+
+      fun output j =
+        let
+          val k = j - ds
+        in
+          (1.0 - a*a) * (if k < 0 then 0.0 else Seq.nth combed k)
+          - (a * Seq.nth combed j)
+        end
+    in
+      { sr = sr
+      , data = Seq.tabulate output (Seq.length data)
+      }
+    end
+
+  val par = ForkJoin.par
+
+  fun par4 (a, b, c, d) =
+    let
+      val ((ar, br), (cr, dr)) =
+        par (fn _ => par (a, b), fn _ => par (c, d))
+    in
+      (ar, br, cr, dr)
+    end
+
+  fun shiftBy n s i =
+    if i < n then
+      0.0
+    else if i < Seq.length s + n then
+      Seq.nth s (i-n)
+    else
+      0.0
+
+  fun reverb (dry: sound) =
+    let
+      val N = Seq.length (#data dry)
+
+      val sr = #sr dry
+      val srr = Real.fromInt sr
+      fun secondsToSamples sec = Real.round (sec * srr)
+
+      fun secondsAt441 samples = Real.fromInt samples / 44100.0
+
+      (* ==========================================
+       * Fused reflections near 50ms
+       * (at 44.1kHz, 50ms is about 2200 samples)
+       *
+       * The basic design is taken from
+       *   The Computer Music Tutorial (1996), page 481
+       *   Author: Curtis Roads
+       *
+       * The basic design is 4 comb filters (in parallel)
+       * which are then fed into two allpass filters, in series.
+       *
+       * Originally, I tuned the comb and allPass parameters
+       * based on numbers of samples at 44.1 kHz, which I chose
+       * to be relatively prime to one another. But now, to
+       * handle any sample rate, I switched to parameters
+       * expressed in seconds. Does it really matter if the
+       * sample delays are relatively prime? I'm not sure. For
+       * sample rates other than 44.1 kHz, they almost certainly
+       * won't be now.
+       *)
+
+      val (c1, c2, c3, c4) =
+        par4 (fn _ => delay (secondsAt441 1931) 0.7 dry,
+              fn _ => delay (secondsAt441 2213) 0.7 dry,
+              fn _ => delay (secondsAt441 1747) 0.7 dry,
+              fn _ => delay (secondsAt441 1559) 0.7 dry)
+
+      fun combs i =
+        (Seq.nth (#data c1) i +
+         Seq.nth (#data c2) i +
+         Seq.nth (#data c3) i +
+         Seq.nth (#data c4) i)
+
+      val fused = {sr = sr, data = Seq.tabulate combs N}
+      val fused = allPass (secondsAt441 167) 0.6 fused
+      val fused = allPass (secondsAt441 191) 0.6 fused
+
+      (* ==========================================
+       * early reflections are single echos of
+       * the dry sound that occur after around
+       * 25ms delay
+       *)
+      val ed1 = secondsToSamples (secondsAt441 1013)
+      val ed2 = secondsToSamples (secondsAt441 1102)
+      val ed3 = secondsToSamples (secondsAt441 1300)
+
+      (* ==========================================
+       * wet signal = dry + early + fused
+       * the fused reflections start emerging after
+       * approximately 35ms
+       *)
+      val fusedDelay = secondsToSamples (secondsAt441 1500)
+
+      val wet = Seq.tabulate (fn i =>
+          shiftBy 0 (#data dry) i
+          + 0.6 * (shiftBy ed1 (#data dry) i)
+          + 0.5 * (shiftBy ed2 (#data dry) i)
+          + 0.4 * (shiftBy ed3 (#data dry) i)
+          + 0.75 * (shiftBy fusedDelay (#data fused) i))
+        (N + fusedDelay)
+
+    in
+      (* wet *)
+      NewWaveIO.compress 2.0 {sr=sr, data=wet}
+    end
+
+end

--- a/examples/lib/sources.mlb
+++ b/examples/lib/sources.mlb
@@ -1,5 +1,6 @@
 $(SML_LIB)/basis/basis.mlb
 $(SML_LIB)/basis/fork-join.mlb
+$(SML_LIB)/basis/mpl.mlb
 
 CommandLineArgs.sml
 Util.sml
@@ -21,3 +22,7 @@ ReadFile.sml
 Tokenize.sml
 
 PPM.sml
+
+Parse.sml
+NewWaveIO.sml
+Signal.sml

--- a/examples/src/reverb/main.sml
+++ b/examples/src/reverb/main.sml
@@ -1,0 +1,33 @@
+structure CLA = CommandLineArgs
+
+fun usage () =
+  let
+    val msg =
+      "usage: reverb INPUT.wav [-output OUTPUT.wav]\n"
+  in
+    TextIO.output (TextIO.stdErr, msg);
+    OS.Process.exit OS.Process.failure
+  end
+
+val infile =
+  case CLA.positional () of
+    [x] => x
+  | _ => usage ()
+
+val outfile = CLA.parseString "output" ""
+
+val (snd, tm) = Util.getTime (fn _ => NewWaveIO.readSound infile)
+val _ = print ("read sound in " ^ Time.fmt 4 tm ^ "s\n")
+
+val (rsnd, tm) = Util.getTime (fn _ => Signal.reverb snd)
+val _ = print ("reverberated in " ^ Time.fmt 4 tm ^ "s\n")
+
+val _ =
+  if outfile = "" then
+    print ("use -output file.wav to hear results\n")
+  else
+    let
+      val (_, tm) = Util.getTime (fn _ => NewWaveIO.writeSound rsnd outfile)
+    in
+      print ("wrote output in " ^ Time.fmt 4 tm ^ "s\n")
+    end

--- a/examples/src/reverb/sources.mlb
+++ b/examples/src/reverb/sources.mlb
@@ -1,0 +1,2 @@
+../../lib/sources.mlb
+main.sml


### PR DESCRIPTION
Based on a design presented in this book:

> The Computer Music Tutorial (1996), page 481
> Author: Curtis Roads

Consists of 4 comb filters in parallel, fed into 2 all-pass filters in series. I also added a small amount of dynamic range compression to make everything crispy. I tuned the frequencies of the comb and all-pass filters to get something interesting: I'd say it sounds reminiscent of using a PA system in, say, a small lobby.

This patch also includes some basic support for `.wav` I/O. At the moment, the library can handle 8- and 16-bit PCM formats. If input files are multi-channel, they are immediately mixed to mono.