### PR TITLE
New example: content-aware image resizing with seam-carving

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,7 +12,8 @@ PROGRAMS= \
 	nn \
 	dedup \
 	nqueens \
-	reverb
+	reverb \
+	seam-carve
 
 all: $(PROGRAMS)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,3 +117,16 @@ are multiple channels, these will be mixed into a mono-channel output.
 $ make reverb
 $ bin/reverb @mpl procs 4 -- INPUT.wav -output OUTPUT.wav
 ```
+
+## Seam-carving
+
+Seam-carving is a content-aware image resizing algorithm that
+rescales an image while attempting to preserve the interesting
+features of the image. This implementation removes vertical seams
+from a `.ppm` given as input. Use `-num-seams` to specify
+how many seams to remove, and `-output` to see a visualization of
+the process.
+```
+$ make seam-carve
+$ bin/seam-carve @mpl procs 4 -- INPUT.ppm -output OUTPUT.gif -num-seams 100
+```

--- a/examples/lib/Color.sml
+++ b/examples/lib/Color.sml
@@ -1,0 +1,79 @@
+structure Color =
+struct
+  type channel = Word8.word
+  type pixel = {red: channel, green: channel, blue: channel}
+
+  val white: pixel = {red=0w255, green=0w255, blue=0w255}
+  val black: pixel = {red=0w0, green=0w0, blue=0w0}
+  val red: pixel = {red=0w255, green=0w0, blue=0w0}
+  val blue: pixel = {red=0w0, green=0w0, blue=0w255}
+
+  fun packInt ({red, green, blue}: pixel) =
+    let
+      fun b x = Word8.toInt x
+    in
+      (65536 * b red) + (256 * b green) + b blue
+    end
+
+  fun compare (p1, p2) = Int.compare (packInt p1, packInt p2)
+
+  fun equal (p1, p2) = (compare (p1, p2) = EQUAL)
+
+  (* Based on the "low-cost approximation" given at
+   * https://www.compuphase.com/cmetric.htm *)
+  fun approxHumanPerceptionDistance
+      ({red=r1, green=g1, blue=b1}, {red=r2, green=g2, blue=b2}) =
+    let
+      fun c x = Word8.toInt x
+      val (r1, g1, b1, r2, g2, b2) = (c r1, c g1, c b1, c r2, c g2, c b2)
+
+      val rmean = (r1 + r2) div 2
+      val r = r1 - r2
+      val g = g1 - g2
+      val b = b1 - b2
+    in
+      Math.sqrt (Real.fromInt
+        ((((512+rmean)*r*r) div 256) + 4*g*g + (((767-rmean)*b*b) div 256)))
+    end
+
+  local
+    fun c x = Word8.toInt x
+    fun sq x = x * x
+  in
+  fun sqDistance ({red=r1, green=g1, blue=b1}, {red=r2, green=g2, blue=b2}) =
+    sq (c r2 - c r1) + sq (c g2 - c g1) + sq (c b2 - c b1)
+  end
+
+  fun distance (p1, p2) = Math.sqrt (Real.fromInt (sqDistance (p1, p2)))
+
+  (* hue in range [0,360)
+   * saturation in range [0,1]
+   * value in range [0,1]
+   *)
+  fun hsv {h: real, s: real, v: real}: pixel =
+    let
+      val H = h
+      val S = s
+      val V = v
+
+      (* from https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB *)
+      val C = V * S
+      val H' = H / 60.0
+      val X = C * (1.0 - Real.abs (Real.rem (H', 2.0) - 1.0))
+
+      val (R1, G1, B1) =
+        if H' < 1.0 then      (C,   X,   0.0)
+        else if H' < 2.0 then (X,   C,   0.0)
+        else if H' < 3.0 then (0.0, C,   X)
+        else if H' < 4.0 then (0.0, X,   C)
+        else if H' < 5.0 then (X,   0.0, C)
+        else                  (C,   0.0, X)
+
+      val m = V - C
+
+      fun to256 channel =
+        Word8.fromInt (Real.ceil (channel * 255.0))
+    in
+      {red = to256 (R1 + m), green = to256 (G1 + m), blue = to256 (B1 + m)}
+    end
+end

--- a/examples/lib/ExtraBinIO.sml
+++ b/examples/lib/ExtraBinIO.sml
@@ -1,0 +1,73 @@
+structure ExtraBinIO =
+struct
+
+  fun w8 file (w: Word8.word) = BinIO.output1 (file, w)
+
+  fun w64b file (w: Word64.word) =
+    let
+      val w8 = w8 file
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w56));
+      w8 (Word8.fromLarge (w >> 0w48));
+      w8 (Word8.fromLarge (w >> 0w40));
+      w8 (Word8.fromLarge (w >> 0w32));
+      w8 (Word8.fromLarge (w >> 0w24));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w32b file (w: Word32.word) =
+    let
+      val w8 = w8 file
+      val w = Word32.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w24));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w32l file (w: Word32.word) =
+    let
+      val w8 = w8 file
+      val w = Word32.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge w);
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge (w >> 0w16));
+      w8 (Word8.fromLarge (w >> 0w24))
+    end
+
+  fun w16b file (w: Word16.word) =
+    let
+      val w8 = w8 file
+      val w = Word16.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge (w >> 0w8));
+      w8 (Word8.fromLarge w)
+    end
+
+  fun w16l file (w: Word16.word) =
+    let
+      val w8 = w8 file
+      val w = Word16.toLarge w
+      open Word64
+      infix 2 >> andb
+    in
+      w8 (Word8.fromLarge w);
+      w8 (Word8.fromLarge (w >> 0w8))
+    end
+
+  fun wrgb file ({red, green, blue}: Color.pixel) =
+    ( w8 file red; w8 file green; w8 file blue )
+
+end

--- a/examples/lib/GIF.sml
+++ b/examples/lib/GIF.sml
@@ -1,0 +1,714 @@
+structure GIF:
+sig
+  type pixel = Color.pixel
+  type image = {height: int, width: int, data: pixel Seq.t}
+
+  (* A GIF color palette is a table of up to 256 colors, and
+   * function for remapping the colors of an image. *)
+  structure Palette:
+  sig
+    type t = {colors: pixel Seq.t, remap: image -> int Seq.t}
+
+    (* Selects a set of "well-spaced" colors sampled from the image.
+     * The first argument is a list of required colors, that must be
+     * included in the palette. Second number is desired palette size.
+     *)
+    val summarize: pixel list -> int -> image -> t
+
+    (* Selects a quantized color palette. *)
+    val quantized: (int * int * int) -> t
+
+    val remapColor: t -> pixel -> int
+  end
+
+  structure LZW:
+  sig
+    (* First step of compression. Remap an image with the given color
+     * palette, and then generate the LZW-compressed code stream.
+     * This inserts clear- and EOI codes.
+     *
+     * arguments are
+     *   1. number of colors, and
+     *   2. color indices (from palette remap)
+     *)
+    val codeStream: int -> int Seq.t -> int Seq.t
+
+    (* Second step of compression: pack the code stream into bits with
+     * flexible bit-lengths. This step also inserts sub-block sizes.
+     * The first argument is the number of colors. *)
+    val packCodeStream: int -> int Seq.t -> Word8.word Seq.t
+  end
+
+  (* Write many images as an animation. All images must be the same dimension. *)
+  val writeMany: string  (* output path *)
+              -> int     (* microsecond delay between images *)
+              -> Palette.t
+              -> {width: int, height: int, numImages: int, getImage: int -> int Seq.t}
+              -> unit
+
+  val write: string -> image -> unit
+end =
+struct
+
+  structure AS = ArraySlice
+
+  type pixel = Color.pixel
+  type image = {height: int, width: int, data: pixel Seq.t}
+
+  fun err msg =
+    raise Fail ("GIF: " ^ msg)
+
+  fun stderr msg =
+    (TextIO.output (TextIO.stdErr, msg); TextIO.output (TextIO.stdErr, "\n"))
+
+  fun ceilLog2 n =
+    if n <= 0 then
+      err "ceilLog2: expected input at least 1"
+    else
+      (* Util.log2(x) computes 1 + floor(log_2(x)) *)
+      Util.log2 (n-1)
+
+  structure Palette =
+  struct
+
+    type t = {colors: pixel Seq.t, remap: image -> int Seq.t}
+
+    fun remapColor ({remap, ...}: t) px =
+      Seq.nth (remap {width=1, height=1, data=Seq.fromList [px]}) 0
+
+    fun makeQuantized (rqq, gqq, bqq) =
+      let
+        fun bucketSize numBuckets =
+          Real.floor (1.0 + 255.0 / Real.fromInt numBuckets)
+        fun bucketShift numBuckets =
+          Word8.fromInt ((255 - (numBuckets-1)*(bucketSize numBuckets)) div 2)
+
+        fun qi nb = fn c => Word8.toInt c div (bucketSize nb)
+        fun qc nb = fn i => bucketShift nb + Word8.fromInt (i * bucketSize nb)
+
+        fun makeQ nb =
+          { numBuckets = nb
+          , channelToIdx = qi nb
+          , channelFromIdx = qc nb
+          }
+
+        val R = makeQ rqq
+        val G = makeQ gqq
+        val B = makeQ bqq
+        val numQuantized = (* this should be at most 256 *)
+          List.foldl op* 1 (List.map #numBuckets [R, G, B])
+
+        fun channelIndices {red, green, blue} =
+          (#channelToIdx R red, #channelToIdx G green, #channelToIdx B blue)
+
+        fun packChannelIndices (r, g, b) =
+          b +
+          g * (#numBuckets B) +
+          r * (#numBuckets B) * (#numBuckets G)
+
+        fun colorOfQuantizeIdx i =
+          let
+            val b = i mod (#numBuckets B)
+            val g = (i div (#numBuckets B)) mod (#numBuckets G)
+            val r = (i div (#numBuckets B) div (#numBuckets G)) mod (#numBuckets R)
+          in
+            { red = #channelFromIdx R r
+            , green = #channelFromIdx G g
+            , blue = #channelFromIdx B b
+            }
+          end
+      in
+        (numQuantized, channelIndices, packChannelIndices, colorOfQuantizeIdx)
+      end
+
+    fun quantized qpackage =
+      let
+        val (numQuantized, channelIndices, pack, colorOfQuantizeIdx) =
+          makeQuantized qpackage
+      in
+        { colors = Seq.tabulate colorOfQuantizeIdx numQuantized
+        , remap = fn ({data, ...}: image) =>
+            AS.full (SeqBasis.tabulate 1000 (0, Seq.length data) (fn i =>
+              pack (channelIndices (Seq.nth data i))))
+        }
+      end
+
+    fun summarize requiredColors paletteSize ({data, width, height}: image) =
+      if paletteSize <= 0 then
+        err "summarize: palette size must be at least 1"
+      else if paletteSize > 256 then
+        err "summarize: max palette size is 256"
+      else if List.length requiredColors > paletteSize then
+        err "summarize: Too many required colors"
+      else
+      let
+        val n = Seq.length data
+
+        val dist = Color.sqDistance
+
+        val dimBits = 3
+        val dim = Util.pow2 dimBits
+        val numBuckets = dim*dim*dim
+        fun chanIdx chan =
+          Word8.toInt (Word8.>> (chan, Word.fromInt (8 - dimBits)))
+        fun chanIdxs {red, green, blue} =
+          (chanIdx red, chanIdx green, chanIdx blue)
+        fun pack (r, g, b) = (dim*dim)*r + dim*g + b
+
+        val table = Array.array (numBuckets, [])
+        val sz = ref 0
+        fun tableSize () = !sz
+
+        fun insert color =
+          let
+            val i = pack (chanIdxs color)
+            val inBucket = Array.sub (table, i)
+          in
+            Array.update (table, i, color :: inBucket);
+            sz := !sz + 1
+          end
+
+        fun bounds x = (Int.max (0, x-1), Int.min (dim, x+2))
+
+        fun minDist color =
+          let
+            val (r, g, b) = chanIdxs color
+          in
+            Util.loop (bounds r) (valOf Int.maxInt) (fn (md, r) =>
+            Util.loop (bounds g) md (fn (md, g) =>
+            Util.loop (bounds b) md (fn (md, b) =>
+              List.foldl (fn (c, md) => Int.min (md, dist (c, color)))
+                md
+                (Array.sub (table, pack (r, g, b)) ))))
+          end
+
+        val candidatesSize = 20
+
+        fun sample i =
+          Seq.nth data (Util.hash i mod n)
+
+        fun chooseColorsLoop i =
+          if tableSize () = paletteSize then () else
+          let
+            fun minDist' px = (px, minDist px)
+            fun chooseMax ((c1, dc1), (c2, dc2)) =
+              if dc1 > dc2 then (c1, dc1) else (c2, dc2)
+            val (c, _) =
+              Util.loop (0, candidatesSize) (Color.black, ~1)
+              (fn (best, j) => chooseMax (best, minDist' (sample (i+j))))
+          in
+            insert c;
+            chooseColorsLoop (i + candidatesSize)
+          end
+
+        (* First, demand that there are a few simple colors in there! *)
+        val _ = List.app insert requiredColors
+
+        (* Now, loop until full *)
+        val _ = chooseColorsLoop 0
+
+        (* Compact the table *)
+        val buckets = AS.full table
+        val bucketSizes = Seq.map List.length buckets
+        val bucketOffsets =
+          AS.full (SeqBasis.scan 100 op+ 0 (0, numBuckets) (Seq.nth bucketSizes))
+        val palette = ForkJoin.alloc paletteSize
+        val _ =
+          Util.for (0, numBuckets) (fn i =>
+            ignore (Util.copyListIntoArray
+              (Seq.nth buckets i)
+              palette
+              (Seq.nth bucketOffsets i)))
+        val palette = AS.full palette
+
+        (* remap by lookup into compacted table *)
+        fun remapOne color =
+          let
+            val (r, g, b) = chanIdxs color
+
+            fun chooseMin ((c1, dc1), (c2, dc2)) =
+              if dc1 <= dc2 then (c1, dc1) else (c2, dc2)
+
+            val (i, _) =
+              Util.loop (bounds r) (~1, valOf Int.maxInt) (fn (md, r) =>
+              Util.loop (bounds g) md (fn (md, g) =>
+              Util.loop (bounds b) md (fn (md, b) =>
+                let
+                  val bucketIdx = pack (r, g, b)
+                  val bStart = Seq.nth bucketOffsets bucketIdx
+                  val bEnd = Seq.nth bucketOffsets (bucketIdx+1)
+                in
+                  Util.loop (bStart, bEnd) md (fn (md, i) =>
+                    chooseMin (md, (i, dist (color, Seq.nth palette i))))
+                end)))
+          in
+            Int.max (0, i)
+          end
+
+        fun remap {width, height, data} =
+          AS.full (SeqBasis.tabulate 100 (0, Seq.length data)
+                    (remapOne o Seq.nth data))
+      in
+        {colors = palette, remap = remap}
+      end
+
+  end
+
+  (* =================================================================== *)
+
+  structure CodeTable:
+  sig
+    type t
+    type idx = int
+    type code = int
+
+    val new: int -> t (* `new numColors` *)
+    val clear: t -> unit
+    val insert: (code * idx) -> t -> bool (* returns false when full *)
+    val maybeLookup: (code * idx) -> t -> code option
+  end =
+  struct
+    type idx = int
+    type code = int
+
+    exception Invalid
+
+    type t =
+      { nextCode: int ref
+      , numColors: int
+      , table: (idx * code) list array
+      }
+
+    fun new numColors =
+      { nextCode = ref (Util.boundPow2 numColors + 2)
+      , numColors = numColors
+      , table = Array.array (4096, [])
+      }
+
+    fun clear {nextCode, numColors, table} =
+      ( Util.for (0, Array.length table) (fn i => Array.update (table, i, []))
+      ; nextCode := Util.boundPow2 numColors + 2
+      )
+
+    fun insert (code, idx) ({nextCode, numColors, table}: t) =
+      if !nextCode = 4095 then
+        false (* GIF limits the maximum code number to 4095 *)
+      else
+        ( Array.update (table, code, (idx, !nextCode) :: Array.sub (table, code))
+        ; nextCode := !nextCode + 1
+        ; true
+        )
+
+    fun maybeLookup (code, idx) ({table, numColors, ...}: t) =
+      case List.find (fn (i, c) => i = idx) (Array.sub (table, code)) of
+        SOME (_, c) => SOME c
+      | NONE => NONE
+
+  end
+
+  (* =================================================================== *)
+
+  structure DynArray =
+  struct
+    type 'a t = 'a array * int
+
+    fun new () =
+      (ForkJoin.alloc 100, 0)
+
+    fun push x (data, nextIdx) =
+      if nextIdx < Array.length data then
+        (Array.update (data, nextIdx, x); (data, nextIdx+1))
+      else
+        let
+          val data' = ForkJoin.alloc (2 * Array.length data)
+        in
+          Util.for (0, Array.length data) (fn i =>
+            Array.update (data', i, Array.sub (data, i)));
+          Array.update (data', nextIdx, x);
+          (data', nextIdx+1)
+        end
+
+    fun toSeq (data, nextIdx) =
+      AS.slice (data, 0, SOME nextIdx)
+  end
+
+(*
+  structure DynArrayList =
+  struct
+    type 'a t = int * 'a array * ('a array list)
+
+    val chunkSize = 256
+
+    fun new () =
+      (0, ForkJoin.alloc chunkSize, [])
+
+    fun push x (nextIdx, chunk, tail) =
+      ( Array.update (chunk, nextIdx, x)
+      ; if nextIdx+1 < chunkSize then
+          (nextIdx+1, chunk, tail)
+        else
+          (0, ForkJoin.alloc chunkSize, chunk :: tail)
+      )
+
+    fun toSeq (nextIdx, chunk, tail) =
+      let
+        val totalSize = nextIdx + (chunkSize * List.length tail)
+        val result = ForkJoin.alloc totalSize
+
+        fun writeChunks cs i =
+          case cs of
+            [] => ()
+          | c :: cs' =>
+              ( Array.copy {src = c, dst = result, di = i - Array.length c}
+              ; writeChunks cs' (i - Array.length c)
+              )
+      in
+        Util.for (0, nextIdx) (fn i =>
+          Array.update (result, totalSize - nextIdx + i, Array.sub (chunk, i)));
+        writeChunks tail (totalSize - nextIdx);
+        AS.full result
+      end
+  end
+*)
+
+(*
+  structure DynList =
+  struct
+    type 'a t = 'a list
+    fun new () = []
+    fun push x list = x :: list
+    fun toSeq xs = Seq.rev (Seq.fromList xs)
+  end
+*)
+
+  (* =================================================================== *)
+
+
+  structure LZW =
+  struct
+
+    structure T = CodeTable
+    structure DS = DynArray
+
+    fun codeStream numColors colorIndices =
+      let
+        fun colorIdx i = Seq.nth colorIndices i
+
+        val clear = Util.boundPow2 numColors
+        val eoi = clear + 1
+
+        val table = T.new numColors
+
+        fun finish stream =
+          DS.toSeq (DS.push eoi stream)
+
+        (* The buffer is implicit, represented instead by currentCode
+         * i is the next index into `colorIndices` *)
+        fun loop stream currentCode i =
+          if i >= Seq.length colorIndices then
+            finish (DS.push currentCode stream)
+          else
+            case T.maybeLookup (currentCode, colorIdx i) table of
+              SOME code => loop stream code (i+1)
+            | NONE =>
+                if T.insert (currentCode, colorIdx i) table then
+                  loop (DS.push currentCode stream) (colorIdx i) (i+1)
+                else
+                  ( T.clear table
+                  ; loop (DS.push clear (DS.push currentCode stream))
+                      (colorIdx i) (i+1)
+                  )
+      in
+        if Seq.length colorIndices = 0 then
+          err "empty color index sequence"
+        else
+          loop (DS.push clear (DS.new ())) (colorIdx 0) 1
+      end
+
+    (* val codeStream = fn image => fn palette =>
+      let
+        val (result, tm) = Util.getTime (fn _ => codeStream image palette)
+      in
+        print ("computed codeStream in " ^ Time.fmt 4 tm ^ "s\n");
+        result
+      end *)
+
+    fun packCodeStream numColors codes =
+      let
+        val n = Seq.length codes
+        fun code i = Seq.nth codes i
+        val clear = Util.boundPow2 numColors
+        val eoi = clear+1
+        val minCodeSize = ceilLog2 numColors
+        val firstCodeWidth = minCodeSize+1
+
+        (* Begin by calculating the bit width of each code. Since we know bit
+         * widths are reset at each clear code, we can parallelize by splitting
+         * the codestream into segments delimited by clear codes and processing
+         * the segments in parallel.
+         *
+         * Within a segment, the width is increased every time we generated
+         * a new code with power-of-two width. Every symbol in the code stream
+         * corresponds to a newly generated code.
+         *)
+
+        val clears =
+          AS.full (SeqBasis.filter 2000 (0, n) (fn i => i) (fn i => code i = clear))
+        val numClears = Seq.length clears
+
+        val widths = ForkJoin.alloc n
+        val _ = Array.update (widths, 0, firstCodeWidth)
+        val _ = ForkJoin.parfor 1 (0, numClears) (fn c =>
+          let
+            val i = 1 + Seq.nth clears c
+            val j = if c = numClears-1 then n else 1 + Seq.nth clears (c+1)
+
+            (* max code in table, up to (but not including) index k *)
+            fun currentMaxCode k =
+              k - i  (* num outputs since the table was cleared *)
+              + eoi  (* the max code immediately after clearing the table *)
+          in
+            Util.loop (i, j) (firstCodeWidth, Util.pow2 firstCodeWidth)
+            (fn ((currWidth, cwPow2), k) =>
+              ( Array.update (widths, k, currWidth)
+              ; if currentMaxCode (k+1) <> cwPow2 then
+                  (currWidth, cwPow2)
+                else
+                  (currWidth+1, cwPow2*2)
+              ));
+            ()
+          end)
+        val widths = AS.full widths
+
+        val totalBitWidth = Seq.reduce op+ 0 widths
+        val packedSize = Util.ceilDiv totalBitWidth 8
+
+        val packed = ForkJoin.alloc packedSize
+
+        fun flushBuffer (oi, buffer, used) =
+          if used < 8 then
+            (oi, buffer, used)
+          else
+            ( Array.update (packed, oi, Word8.fromLarge buffer)
+            ; flushBuffer (oi+1, LargeWord.>> (buffer, 0w8), used-8)
+            )
+
+        (* Input index range [ci,cj)
+         * Output index range [oi, oj)
+         * `buffer` is a partially filled byte that has not yet been written
+         * to the packed. `used` (0 to 7) is how much of that byte is
+         * used. *)
+        fun pack (oi, oj) (ci, cj) (buffer: LargeWord.word) (used: int) =
+          if ci >= cj then
+            (if oi >= oj then
+              ()
+            else if oi = oj-1 then
+              Array.update (packed, oi, Word8.fromLarge buffer)
+            else
+              err "cannot fill rest of packed region")
+          else
+            let
+              val thisCode = code ci
+              val thisWidth = Seq.nth widths ci
+              val buffer' =
+                LargeWord.orb (buffer,
+                  LargeWord.<< (LargeWord.fromInt thisCode, Word.fromInt used))
+              val used' = used + thisWidth
+              val (oi', buffer'', used'') = flushBuffer (oi, buffer', used')
+            in
+              pack (oi', oj) (ci+1, cj) buffer'' used''
+            end
+
+        val _ = pack (0, packedSize) (0, n) 0w0 0
+        val packed = AS.full packed
+        val numBlocks = Util.ceilDiv packedSize 255
+        val output = ForkJoin.alloc (packedSize + numBlocks + 1)
+      in
+        ForkJoin.parfor 10 (0, numBlocks) (fn i =>
+          let
+            val size = if i < numBlocks-1 then 255 else packedSize - 255*i
+          in
+            Array.update (output, 256*i, Word8.fromInt size);
+            Util.for (0, size) (fn j =>
+              Array.update (output, 256*i + 1 + j, Seq.nth packed (255*i + j)))
+          end);
+
+        Array.update (output, packedSize + numBlocks, 0w0);
+
+        AS.full output
+      end
+  end
+
+  (* ====================================================================== *)
+
+  fun checkToWord16 thing x =
+    if x >= 0 andalso x <= 65535 then
+      Word16.fromInt x
+    else
+      err (thing ^ " must be non-negative and less than 2^16");
+
+  fun packScreenDescriptorByte
+        { colorTableFlag: bool
+        , colorResolution: int
+        , sortFlag: bool
+        , colorTableSize: int
+        } =
+    let
+      open Word8
+      infix 2 << orb andb
+    in
+      ((if colorTableFlag then 0w1 else 0w0) << 0w7)
+      orb
+      ((fromInt colorResolution andb 0wx7) << 0w4)
+      orb
+      ((if sortFlag then 0w1 else 0w0) << 0w3)
+      orb
+      (fromInt colorTableSize andb 0wx7)
+    end
+
+  fun writeMany path delay palette {width, height, numImages, getImage} =
+    if numImages <= 0 then
+      err "Must be at least one image"
+    else
+    let
+      val width16 = checkToWord16 "width" width
+      val height16 = checkToWord16 "height" height
+
+      val numberOfColors = Seq.length (#colors palette)
+
+      val _ =
+        if numberOfColors <= 256 then ()
+        else err "Must have at most 256 colors in the palette"
+
+      val (imageData, tm) = Util.getTime (fn _ =>
+        AS.full (SeqBasis.tabulate 1 (0, numImages) (fn i =>
+          let
+            val img = getImage i
+          in
+            if Seq.length img <> height * width then
+              err "Not all images are the right dimensions"
+            else
+              LZW.packCodeStream numberOfColors
+                (LZW.codeStream numberOfColors img)
+          end)))
+
+      (* val _ = print ("compressed image data in " ^ Time.fmt 4 tm ^ "s\n") *)
+
+      val file = BinIO.openOut path
+      val w8 = ExtraBinIO.w8 file
+      val w32b = ExtraBinIO.w32b file
+      val w32l = ExtraBinIO.w32l file
+      val w16l = ExtraBinIO.w16l file
+      val wrgb = ExtraBinIO.wrgb file
+    in
+      (* ==========================
+       * "GIF89a" header: 6 bytes
+       *)
+
+      List.app (w8 o Word8.fromInt) [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+
+      (* ===================================
+       * logical screen descriptor: 7 bytes
+       *)
+
+      w16l width16;
+      w16l height16;
+
+      w8 (packScreenDescriptorByte
+        { colorTableFlag  = true
+        , colorResolution = 1
+        , sortFlag        = false
+        , colorTableSize  = (ceilLog2 numberOfColors) - 1
+        });
+
+      w8 0w0; (* background color index. just use 0 for now. *)
+
+      w8 0w0; (* pixel aspect ratio ?? *)
+
+      (* ===================================
+       * global color table
+       *)
+
+      Util.for (0, numberOfColors) (fn i =>
+        wrgb (Seq.nth (#colors palette) i));
+
+      Util.for (numberOfColors, Util.boundPow2 numberOfColors) (fn i =>
+        wrgb Color.black);
+
+      (* ==================================
+       * application extension, for looping
+       * OPTIONAL. skip it if there is only one image.
+       *)
+
+      if numImages = 1 then () else
+      List.app (w8 o Word8.fromInt)
+      [ 0x21, 0xFF, 0x0B, 0x4E, 0x45, 0x54, 0x53, 0x43, 0x41, 0x50, 0x45, 0x32
+      , 0x2E, 0x30, 0x03, 0x01, 0x00, 0x00, 0x00
+      ];
+
+      (* ==================================
+       * IMAGE DATA
+       *)
+
+      Util.for (0, numImages) (fn i =>
+        let
+          val bytes = Seq.nth imageData i
+        in
+          (* ==========================
+           * graphics control extension.
+           * OPTIONAL. only needed if
+           * doing animation.
+           *)
+
+          if numImages = 1 then () else
+          ( List.app (w8 o Word8.fromInt) [ 0x21, 0xF9, 0x04, 0x04 ]
+          ; w16l (Word16.fromInt delay)
+          ; w8 0w0
+          ; w8 0w0
+          );
+
+          (* ==========================
+           * image descriptor
+           *)
+
+          w8 0wx2C; (* image separator *)
+
+          w16l 0w0;  (* image left *)
+          w16l 0w0;  (* image top *)
+
+          w16l width16;  (* image width *)
+          w16l height16; (* image height *)
+
+          w8 0w0;   (* packed local color table descriptor (NONE FOR NOW) *)
+
+          (* ===========================
+           * compressed image data
+           *)
+
+          w8 (Word8.fromInt (ceilLog2 numberOfColors));
+          Util.for (0, Seq.length bytes) (fn i =>
+            w8 (Seq.nth bytes i))
+        end);
+
+      (* ================================
+       * trailer
+       *)
+
+      w8 0wx3B;
+
+      BinIO.closeOut file
+    end
+
+  fun write path img =
+    let
+      val palette = Palette.summarize [] 128 img
+      val img' = #remap palette img
+    in
+      writeMany path 0 palette
+        { width = #width img
+        , height = #height img
+        , numImages = 1
+        , getImage = (fn _ => img')
+        }
+    end
+end

--- a/examples/lib/PPM.sml
+++ b/examples/lib/PPM.sml
@@ -1,16 +1,14 @@
 (* Basic support for the netpbm .ppm file format. *)
 structure PPM:
 sig
-  type channel = Word8.word
-  type pixel = {red: channel, green: channel, blue: channel}
+  type channel = Color.channel
+  type pixel = Color.pixel
 
-  (* sequence of rows, each row must be the same length *)
-  type image = pixel Seq.t Seq.t
-
-  val width: image -> int
-  val height: image -> int
-
+  (* flat sequence; pixel (i, j) is at data[i*width + j] *)
+  type image = {height: int, width: int, data: pixel Seq.t}
   type box = {topleft: int * int, botright: int * int}
+
+  val elem: image -> (int * int) -> pixel
 
   val subimage: box -> image -> image
 
@@ -29,36 +27,53 @@ struct
 
   type 'a seq = 'a Seq.t
 
-  type channel = Word8.word
-  type pixel = {red: channel, green: channel, blue: channel}
-  type image = pixel Seq.t Seq.t
+  type channel = Color.channel
+  type pixel = Color.pixel
+  type image = {height: int, width: int, data: pixel Seq.t}
   type box = {topleft: int * int, botright: int * int}
 
-  fun height image = Seq.length image
-  fun width image =
-    if height image = 0 then 0
-    else Seq.length (Seq.nth image 0)
+  fun elem ({height, width, data}: image) (i, j) =
+    if i < 0 orelse i >= height orelse j < 0 orelse j >= width then
+      raise Subscript
+    else
+      Seq.nth data (i*width + j)
 
   fun subimage {topleft=(i1,j1), botright=(i2,j2)} image =
     let
-      fun elem i j = Seq.nth (Seq.nth image i) j
+      val w = j2-j1
+      val h = i2-i1
+
+      fun newElem k =
+        let
+          val i = k div w
+          val j = k mod w
+        in
+          elem image (i1 + i, j1 + j)
+        end
     in
-      Seq.tabulate
-      (fn i => Seq.tabulate (fn j => elem (i1+i) (j1+j)) (j2-j1))
-      (i2-i1)
+      { width = w
+      , height = h
+      , data = Seq.tabulate newElem (w * h)
+      }
     end
 
   fun replace {topleft=(i1,j1), botright=(i2,j2)} image subimage =
     let
-      fun elem i j =
-        if i1 <= i andalso i < i2 andalso
-           j1 <= j andalso j < j2
-        then Seq.nth (Seq.nth subimage (i-i1)) (j-j1)
-        else Seq.nth (Seq.nth image i) j
+      fun newElem k =
+        let
+          val i = k div (#width image)
+          val j = k mod (#width image)
+        in
+          if i1 <= i andalso i < i2 andalso
+             j1 <= j andalso j < j2
+          then elem subimage (i-i1, j-j1)
+          else elem image (i, j)
+        end
     in
-      Seq.tabulate
-      (fn i => Seq.tabulate (fn j => elem i j) (width image))
-      (height image)
+      { width = #width image
+      , height = #height image
+      , data = Seq.tabulate newElem (#width image * #height image)
+      }
     end
 
   (* utilities... *)
@@ -71,11 +86,19 @@ struct
 
   fun parse3 contents =
     let
-      val tokens = Seq.fromList (String.tokens Char.isSpace contents)
-      fun tok i = Seq.nth tokens i
-      val numToks = Seq.length tokens
+      (* val tokens = Seq.fromList (String.tokens Char.isSpace contents) *)
+      (* val numToks = Seq.length tokens *)
+      val (numToks, tokRange) = Tokenize.tokenRanges Char.isSpace contents
+      fun tok i =
+        let
+          val (lo, hi) = tokRange i
+        in
+          Seq.subseq contents (lo, hi-lo)
+        end
+      fun strTok i =
+        Parse.parseString (tok i)
 
-      val filetype = tok 0
+      val filetype = strTok 0
       val _ =
         if filetype = "P3" then ()
         else raise Fail "should not happen"
@@ -84,9 +107,10 @@ struct
         let
           fun err () =
             raise Fail ("error parsing .ppm file: cannot parse "
-                        ^ thingName ^ " from '" ^ niceify (tok i) ^ "'")
+                        ^ thingName ^ " from '"
+                        ^ niceify (strTok i) ^ "'")
         in
-          case Int.fromString (tok i) of
+          case Parse.parseInt (tok i) of
             NONE => err ()
           | SOME x => if x >= 0 then x else err ()
         end
@@ -119,26 +143,26 @@ struct
 
       fun pixel i =
         {red = chan (3*i), green = chan (3*i + 1), blue = chan (3*i + 2)}
-
-      fun row i =
-        Seq.tabulate (fn j => pixel (width*i + j)) width
     in
-      Seq.tabulate row height
+      { width = width
+      , height = height
+      , data = Seq.tabulate pixel (width * height)
+      }
     end
 
   (* ============================== P6 format ============================== *)
 
   fun parse6 contents =
     let
-      val filetype = String.substring (contents, 0, 2)
+      val filetype = Parse.parseString (Seq.subseq contents (0, 2))
       val _ =
         if filetype = "P6" then ()
         else raise Fail "should not happen"
 
       fun findFirst p i =
-        if i >= String.size contents then
+        if i >= Seq.length contents then
           NONE
-        else if p (String.sub (contents, i)) then
+        else if p (Seq.nth contents i) then
           SOME i
         else
           findFirst p (i+1)
@@ -148,31 +172,33 @@ struct
           NONE => NONE
         | SOME i =>
             case findFirst Char.isSpace i of
-              NONE => SOME (i, String.size contents)
+              NONE => SOME (i, Seq.length contents)
             | SOME j => SOME (i, j)
 
       (* start must be on a space *)
       fun chompToken start =
         case findToken start of
           NONE => NONE
-        | SOME (i, j) => SOME (String.substring (contents, i, j-i), j)
+        | SOME (i, j) => SOME (Seq.subseq contents (i, j-i), j)
 
       fun chompInt thingName i =
         case chompToken i of
           NONE => raise Fail ("error parsing .ppm file: missing " ^ thingName)
         | SOME (s, j) =>
-            case Int.fromString s of
+            case Parse.parseInt s of
               NONE => raise Fail ("error parsing .ppm file: cannot parse "
-                                  ^ thingName ^ " from '" ^ niceify s ^ "'")
+                                  ^ thingName ^ " from '"
+                                  ^ niceify (Parse.parseString s) ^ "'")
             | SOME x =>
                 if x >= 0 then (x, j)
                 else raise Fail ("error parsing .ppm file: cannot parse "
-                                 ^ thingName ^ " from '" ^ niceify s ^ "'")
+                                 ^ thingName ^ " from '"
+                                 ^ niceify (Parse.parseString s) ^ "'")
 
       val cursor = 2
       val _ =
-        if String.size contents > 2 andalso
-           Char.isSpace (String.sub (contents, 2))
+        if Seq.length contents > 2 andalso
+           Char.isSpace (Seq.nth contents 2)
         then ()
         else raise Fail "error parsing .ppm file: unexpected format"
 
@@ -192,30 +218,28 @@ struct
         | NONE => raise Fail "error parsing .ppm file: missing contents"
 
       val _ =
-        if String.size contents - cursor >= numChannels then ()
+        if Seq.length contents - cursor >= numChannels then ()
         else raise Fail "error parsing .ppm file: too few color channels"
 
       fun chan i =
-        Word8.fromInt (Char.ord (String.sub (contents, cursor + i)))
+        Word8.fromInt (Char.ord (Seq.nth contents (cursor + i)))
 
       fun pixel i =
         {red = chan (3*i), green = chan (3*i + 1), blue = chan (3*i + 2)}
-
-      fun row i =
-        Seq.tabulate (fn j => pixel (width*i + j)) width
     in
-      Seq.tabulate row height
+      { width = width
+      , height = height
+      , data = Seq.tabulate pixel (width * height)
+      }
     end
 
   (* ================================= read ================================= *)
 
   fun read filepath =
     let
-      val file = TextIO.openIn filepath
-      val contents = TextIO.inputAll file
-      val _ = TextIO.closeIn file
+      val contents = ReadFile.contentsSeq filepath
     in
-      case String.substring (contents, 0, 2) of
+      case Parse.parseString (Seq.subseq contents (0, 2)) of
         "P3" => parse3 contents
       | "P6" => parse6 contents
       | _ => raise Fail "error parsing .ppm file: unknown or unsupported format"
@@ -226,20 +250,13 @@ struct
 
   fun write filepath image =
     let
-      val allRowsSameWidth =
-        Seq.reduce (fn (a, b) => a andalso b) true
-        (Seq.map (fn row => Seq.length row = width image) image)
-      val _ =
-        if allRowsSameWidth then ()
-        else raise Fail ("error writing " ^ filepath ^ ": jagged image")
-
       val file = TextIO.openOut filepath
 
       fun dump str = TextIO.output (file, str)
       fun dumpChan c = TextIO.output1 (file, Char.chr (Word8.toInt c))
       fun dumpPx i j =
         let
-          val {red, green, blue} = Seq.nth (Seq.nth image i) j
+          val {red, green, blue} = elem image (i, j)
         in
           (dumpChan red;
            dumpChan green;
@@ -247,15 +264,15 @@ struct
         end
 
       fun dumpLoop i j =
-        if i >= height image then ()
-        else if j >= width image then
+        if i >= #height image then ()
+        else if j >= #width image then
           dumpLoop (i+1) 0
         else
           (dumpPx i j; dumpLoop i (j+1))
     in
       dump "P6 ";
-      dump (Int.toString (width image) ^ " ");
-      dump (Int.toString (height image) ^ " ");
+      dump (Int.toString (#width image) ^ " ");
+      dump (Int.toString (#height image) ^ " ");
       dump "255 ";
       dumpLoop 0 0
     end

--- a/examples/lib/Seq.sml
+++ b/examples/lib/Seq.sml
@@ -7,17 +7,35 @@ struct
 
   val gran = 10000
 
-  fun empty () = AS.full (A.fromList [])
-
+  fun nth s i = AS.sub (s, i)
   fun length s = AS.length s
 
-  fun subseq s (i, n) = AS.subslice (s, i, SOME n)
+  fun empty () = AS.full (A.fromList [])
+  fun fromList xs = ArraySlice.full (Array.fromList xs)
+  fun toList s = List.tabulate (length s, nth s)
 
-  fun nth s i = AS.sub (s, i)
+  fun toString f s =
+    String.concatWith "," (List.map f (toList s))
+
+  fun subseq s (i, n) = AS.subslice (s, i, SOME n)
+  fun take s k = subseq s (0, k)
+  fun drop s k = subseq s (k, length s - k)
 
   fun tabulate f n = AS.full (SeqBasis.tabulate gran (0, n) f)
 
   fun map f s = tabulate (fn i => f (nth s i)) (length s)
+
+  fun rev s = tabulate (fn i => nth s (length s - i - 1)) (length s)
+
+  fun append (s, t) =
+    tabulate (fn i => if i < length s then nth s i else nth t (i - length s))
+      (length s + length t)
+
+  fun iterate f b s =
+    SeqBasis.foldl f b (0, length s) (nth s)
+
+  fun foreach s f =
+    ForkJoin.parfor gran (0, length s) (fn i => f (i, nth s i))
 
   fun scan f b s =
     let
@@ -27,9 +45,40 @@ struct
       (AS.slice (r, 0, SOME n), A.sub (r, n))
     end
 
-  fun reduce f b s =
-    SeqBasis.reduce 10000 f b (0, length s) (nth s)
+  fun scanIncl f b s =
+    let
+      val n = AS.length s
+      val r = SeqBasis.scan gran f b (0, n) (nth s)
+    in
+      AS.slice (r, 1, NONE)
+    end
 
-  fun fromList xs = ArraySlice.full (Array.fromList xs)
+  fun reduce f b s =
+    SeqBasis.reduce gran f b (0, length s) (nth s)
+
+  fun filter p s =
+    AS.full (SeqBasis.filter gran (0, length s) (nth s) (p o nth s))
+
+  fun equal eq (s, t) =
+    length s = length t andalso
+    SeqBasis.reduce gran (fn (a, b) => a andalso b) true (0, length s)
+      (fn i => eq (nth s i, nth t i))
+
+  fun flatten s =
+    let
+      val offsets = AS.full (SeqBasis.scan 10000 op+ 0 (0, length s) (length o nth s))
+      val total = nth offsets (length s)
+      val output = ForkJoin.alloc total
+    in
+      ForkJoin.parfor 100 (0, length s) (fn i =>
+        let
+          val t = nth s i
+          val off = nth offsets i
+        in
+          foreach t (fn (j, x) => A.update (output, off + j, x))
+        end);
+
+      AS.full output
+    end
 
 end

--- a/examples/lib/Tokenize.sml
+++ b/examples/lib/Tokenize.sml
@@ -1,5 +1,7 @@
 structure Tokenize:
 sig
+  val tokenRanges: (char -> bool) -> char Seq.t -> int * (int -> (int * int))
+
   val tokensSeq: (char -> bool) -> char Seq.t -> (char Seq.t) Seq.t
 
   val tokens: (char -> bool) -> char Seq.t -> string Seq.t
@@ -9,7 +11,6 @@ struct
   fun tokenRanges f s =
     let
       val n = Seq.length s
-      val indices = Seq.tabulate (fn i => i) (n+1)
       fun check i =
         if (i = n) then not (f(Seq.nth s (n-1)))
         else if (i = 0) then not (f(Seq.nth s 0))

--- a/examples/lib/Util.sml
+++ b/examples/lib/Util.sml
@@ -1,7 +1,22 @@
 structure Util:
 sig
   val getTime: (unit -> 'a) -> ('a * Time.time)
+  val reportTime: (unit -> 'a) -> 'a
+
+  val closeEnough: real * real -> bool
+
+  val die: string -> 'a
+
+  val repeat: int * (unit -> 'a)  -> ('a)
+
   val hash64: Word64.word -> Word64.word
+  val hash64_2: Word64.word -> Word64.word
+  val hash32: Word32.word -> Word32.word
+  val hash32_2: Word32.word -> Word32.word
+  val hash32_3: Word32.word -> Word32.word
+  val hash: int -> int
+
+  val ceilDiv: int -> int -> int
 
   val pow2: int -> int
 
@@ -27,8 +42,16 @@ sig
   (* `loop (lo, hi) b f`
    * for lo <= i < hi, iteratively do  b = f (b, i)  *)
   val loop: (int * int) -> 'a -> ('a * int -> 'a) -> 'a
+
+  val copyListIntoArray: 'a list -> 'a array -> int -> int
 end =
 struct
+
+  fun die msg =
+    ( TextIO.output (TextIO.stdErr, msg ^ "\n")
+    ; TextIO.flushOut TextIO.stdErr
+    ; OS.Process.exit OS.Process.failure
+    )
 
   fun getTime f =
     let
@@ -39,21 +62,18 @@ struct
       (result, Time.- (t1, t0))
     end
 
-  fun hash64 u =
+  fun reportTime f =
     let
-      open Word64
-      infix 2 >> << xorb andb
-      val v = u * 0w3935559000370003845 + 0w2691343689449507681
-      val v = v xorb (v << 0w21)
-      val v = v xorb (v << 0w37)
-      val v = v xorb (v >> 0w4)
-      val v = v * 0w4768777513237032717
-      val v = v xorb (v << 0w20)
-      val v = v xorb (v >> 0w41)
-      val v = v xorb (v << 0w5)
+      val (result, tm) = getTime f
     in
-      v
+      print ("time " ^ Time.fmt 4 tm ^ "s\n");
+      result
     end
+
+  fun closeEnough (x, y) =
+    Real.abs (x - y) <= 0.000001
+
+  fun ceilDiv n k = 1 + (n-1) div k
 
   (* NOTE: this actually computes 1 + floor(log_2(n)), i.e. the number of
    * bits required to represent n in binary *)
@@ -77,6 +97,24 @@ struct
     ForkJoin.parfor 4096 (0, ArraySlice.length s)
     (fn i => f (i, ArraySlice.sub (s, i)))
 
+  fun copyListIntoArray xs arr i =
+    case xs of
+      [] => i
+    | x :: xs =>
+        ( Array.update (arr, i, x)
+        ; copyListIntoArray xs arr (i+1)
+        )
+
+  fun repeat (n, f) =
+    let
+      fun rep_help 1 = f()
+      |   rep_help n = ((rep_help (n-1)); f())
+
+      val ns = if (n>0) then n else 1
+    in
+      rep_help ns
+    end
+
   fun summarizeArraySlice count toString xs =
     let
       val n = ArraySlice.length xs
@@ -95,5 +133,143 @@ struct
 
   fun summarizeArray count toString xs =
     summarizeArraySlice count toString (ArraySlice.full xs)
+
+  (* // from numerical recipes
+   * uint64_t hash64(uint64_t u)
+   * {
+   *   uint64_t v = u * 3935559000370003845ul + 2691343689449507681ul;
+   *   v ^= v >> 21;
+   *   v ^= v << 37;
+   *   v ^= v >>  4;
+   *   v *= 4768777513237032717ul;
+   *   v ^= v << 20;
+   *   v ^= v >> 41;
+   *   v ^= v <<  5;
+   *   return v;
+   * }
+   *)
+
+  fun hash64 u =
+    let
+      open Word64
+      infix 2 >> << xorb andb
+      val v = u * 0w3935559000370003845 + 0w2691343689449507681
+      val v = v xorb (v >> 0w21)
+      val v = v xorb (v << 0w37)
+      val v = v xorb (v >> 0w4)
+      val v = v * 0w4768777513237032717
+      val v = v xorb (v << 0w20)
+      val v = v xorb (v >> 0w41)
+      val v = v xorb (v << 0w5)
+    in
+      v
+    end
+
+  (* uint32_t hash32(uint32_t a) {
+   *   a = (a+0x7ed55d16) + (a<<12);
+   *   a = (a^0xc761c23c) ^ (a>>19);
+   *   a = (a+0x165667b1) + (a<<5);
+   *   a = (a+0xd3a2646c) ^ (a<<9);
+   *   a = (a+0xfd7046c5) + (a<<3);
+   *   a = (a^0xb55a4f09) ^ (a>>16);
+   *   return a;
+   * }
+   *)
+
+  fun hash32 a =
+    let
+      open Word32
+      infix 2 >> << xorb
+      val a = (a +    0wx7ed55d16) +    (a << 0w12)
+      val a = (a xorb 0wxc761c23c) xorb (a >> 0w19)
+      val a = (a +    0wx165667b1) +    (a << 0w5)
+      val a = (a +    0wxd3a2646c) xorb (a << 0w9)
+      val a = (a +    0wxfd7046c5) +    (a << 0w3)
+      val a = (a xorb 0wxb55a4f09) xorb (a >> 0w16)
+    in
+      a
+    end
+
+  (* uint32_t hash32_2(uint32_t a) {
+   *   uint32_t z = (a + 0x6D2B79F5UL);
+   *   z = (z ^ (z >> 15)) * (z | 1UL);
+   *   z ^= z + (z ^ (z >> 7)) * (z | 61UL);
+   *   return z ^ (z >> 14);
+   * }
+   *)
+
+  fun hash32_2 a =
+    let
+      open Word32
+      infix 2 >> << xorb orb
+      val z = (a + 0wx6D2B79F5)
+      val z = (z xorb (z >> 0w15)) * (z orb 0w1)
+      val z = z xorb (z + (z xorb (z >> 0w7)) * (z orb 0w61))
+    in
+      z xorb (z >> 0w14)
+    end
+
+  (* inline uint32_t hash32_3(uint32_t a) {
+   *   uint32_t z = a + 0x9e3779b9;
+   *   z ^= z >> 15; // 16 for murmur3
+   *   z *= 0x85ebca6b;
+   *   z ^= z >> 13;
+   *   z *= 0xc2b2ae3d; // 0xc2b2ae35 for murmur3
+   *   return z ^= z >> 16;
+   * }
+   *)
+
+  fun hash32_3 a =
+    let
+      open Word32
+      infix 2 >> << xorb orb
+      val z = a + 0wx9e3779b9
+      val z = z xorb (z >> 0w15)  (* 16 for murmur3 *)
+      val z = z * 0wx85ebca6b
+      val z = z xorb (z >> 0w13)
+      val z = z * 0wxc2b2ae3d     (* 0wxc2b2ae35 for murmur3 *)
+      val z = z xorb (z >> 0w16)
+    in
+      z
+    end
+
+  (* // a slightly cheaper, but possibly not as good version
+   * // based on splitmix64
+   * inline uint64_t hash64_2(uint64_t x) {
+   *   x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+   *   x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+   *   x = x ^ (x >> 31);
+   *   return x;
+   * }
+   *)
+
+  fun hash64_2 x =
+    let
+      open Word64
+      infix 2 >> << xorb orb
+      val x = (x xorb (x >> 0w30)) * 0wxbf58476d1ce4e5b9
+      val x = (x xorb (x >> 0w27)) * 0wx94d049bb133111eb
+      val x = x xorb (x >> 0w31)
+    in
+      x
+    end
+
+  (* This chooses which hash function to use for generic integers, since
+   * integers are configurable at compile time. *)
+  val hash : int -> int =
+    case Int.precision of
+      NONE =>    (Word64.toInt  o hash64 o Word64.fromInt)
+    | SOME 32 => (Word32.toIntX o hash32 o Word32.fromInt)
+    | SOME 64 => (Word64.toIntX o hash64 o Word64.fromInt)
+    | SOME p => (fn x =>
+        let
+          val wp1 = Word.fromInt (p-1)
+          open Word64
+          infix 2 >> << andb
+          val v = hash64 (fromInt x)
+          val v = v andb ((0w1 << wp1) - 0w1)
+        in
+          toInt v
+        end)
 
 end

--- a/examples/lib/sources.mlb
+++ b/examples/lib/sources.mlb
@@ -21,8 +21,11 @@ Geometry2D.sml
 ReadFile.sml
 Tokenize.sml
 
-PPM.sml
-
+Color.sml
+ExtraBinIO.sml
 Parse.sml
+PPM.sml
+GIF.sml
+
 NewWaveIO.sml
 Signal.sml

--- a/examples/src/nn/main.sml
+++ b/examples/src/nn/main.sml
@@ -46,15 +46,12 @@ val resolution = CLA.parseInt "resolution" 1000
 val width = resolution
 val height = resolution
 
-val white: PPM.pixel = {red=0w255, green=0w255, blue=0w255}
-val black: PPM.pixel = {red=0w0, green=0w0, blue=0w0}
-val red: PPM.pixel = {red=0w255, green=0w0, blue=0w0}
+val image = Seq.tabulate (fn i => Color.white) (width * height)
 
-val image = Seq.tabulate (fn i => Seq.tabulate (fn j => white) width) height
 fun set (i, j) x =
   if 0 <= i andalso i < height andalso
      0 <= j andalso j < width
-  then ArraySlice.update (Seq.nth image i, j, x)
+  then ArraySlice.update (image, i*width + j, x)
   else ()
 
 val r = Real.fromInt resolution
@@ -63,7 +60,7 @@ fun pos (x, y) = (resolution - px x - 1, px y)
 
 fun horizontalLine i (j0, j1) =
   if j1 < j0 then horizontalLine i (j1, j0)
-  else Util.for (j0, j1) (fn j => set (i, j) red)
+  else Util.for (j0, j1) (fn j => set (i, j) Color.red)
 
 fun sign xx =
   case Int.compare (xx, 0) of LESS => ~1 | EQUAL => 0 | GREATER => 1
@@ -86,7 +83,7 @@ fun line (x1, y1) (x2, y2) =
       let
         val numerator = numerator + shortest;
       in
-        set (x, y) red;
+        set (x, y) Color.red;
         if numerator >= longest then
           loop (i+1) (numerator-longest) (x+dx1) (y+dy1)
         else
@@ -105,7 +102,7 @@ val _ =
   ForkJoin.parfor 10000 (0, Seq.length input) (fn i =>
     let
       val (x, y) = pos (Seq.nth input i)
-      fun b spot = set spot black
+      fun b spot = set spot Color.black
     in
       b (x-1, y);
       b (x, y-1);
@@ -117,5 +114,6 @@ val _ =
 val t1 = Time.now ()
 val _ = print ("generated image in " ^ Time.fmt 4 (Time.- (t1, t0)) ^ "s\n")
 
+val image = {width = width, height = height, data = image}
 val (_, tm) = Util.getTime (fn _ => PPM.write filename image)
 val _ = print ("wrote to " ^ filename ^ " in " ^ Time.fmt 4 tm ^ "s\n")

--- a/examples/src/seam-carve/SCI.sml
+++ b/examples/src/seam-carve/SCI.sml
@@ -1,0 +1,234 @@
+structure SCI:
+sig
+  type image = PPM.image
+  type seam = int Seq.t
+
+  (* `makeSeamCarveIndex n img` removes `n` seams and returns
+   * a mapping X that indicates the order in which pixels are removed.
+   *
+   * For a pixel at (i,j):
+   *   - if not removed, then X[i*width + j] = -1
+   *   - otherwise, removed in seam number X[i*width + j]
+   *
+   * So, for an image of height H, there will be H pixels that are marked 0
+   * and H other pixels that are marked 1, etc.
+   *)
+  val makeSeamCarveIndex: int -> image -> int Seq.t
+end =
+struct
+
+  type image = PPM.image
+  type seam = int Seq.t
+
+  (* ======================================================================
+   * algorithm to solve the equation
+   *   M(i,j) = E(i,j) + min(M(i-1,j), M(i-1,j-1), M(i-1,j+1))
+   *
+   * Triangular-blocked bottom-up DP does fancy triangular strategy, to
+   * improve granularity.
+   *
+   * Imagine breaking up the image into a bunch of strips, where each strip
+   * is then divided into triangles. If each triangle is processed sequentially
+   * row-wise from top to bottom, then we can compute a strip in parallel
+   * by first doing all of upper triangles (#), and then doing all of the lower
+   * triangles (.):
+   *
+   *             +------------------------------------+
+   *  strip 1 -> |\####/\####/\####/\####/\####/\####/|
+   *             |.\##/..\##/..\##/..\##/..\##/..\##/.|
+   *             |..\/....\/....\/....\/....\/....\/..|
+   *  strip 2 -> |\####/\####/\####/\####/\####/\####/|
+   *             |.\##/..\##/..\##/..\##/..\##/..\##/.|
+   *             |..\/....\/....\/....\/....\/....\/..|
+   *  strip 3 -> |                                    |
+   *)
+
+  val blockWidth = CommandLineArgs.parseInt "block-width" 80
+  val _ = print ("block-width " ^ Int.toString blockWidth ^ "\n")
+  val _ =
+    if blockWidth mod 2 = 0 then ()
+    else Util.die ("block-width must be even!")
+
+  fun triangularBlockedWriteAllMinSeams width height energy minSeamEnergies =
+    let
+      fun M (i, j) =
+        if j < 0 orelse j >= width then Real.posInf
+        else Array.sub (minSeamEnergies, i*width + j)
+      fun setM (i, j) =
+        let
+          val x =
+            if i = 0 then 0.0
+            else energy (i, j) +
+                 Real.min (M (i-1, j), Real.min (M (i-1, j-1), M (i-1, j+1)))
+        in
+          Array.update (minSeamEnergies, i*width + j, x)
+        end
+
+      val blockHeight = blockWidth div 2
+      val numBlocks = 1 + (width - 1) div blockWidth
+
+      (* Fill in a triangle starting at row i, centered at jMid, with
+       * the fat end at top and small end at bottom.
+       *
+       * For example with blockWidth 6:
+       *               jMid
+       *                |
+       *      i -- X X X X X X
+       *             X X X X
+       *               X X
+       *)
+      fun upperTriangle i jMid =
+        Util.for (0, Int.min (height-i, blockHeight)) (fn k =>
+          let
+            val lo = Int.max (0, jMid-blockHeight+k)
+            val hi = Int.min (width, jMid+blockHeight-k)
+          in
+            Util.for (lo, hi) (fn j => setM (i+k, j))
+          end)
+
+      (* The other way around. For example with blockWidth 6:
+       *               jMid
+       *                |
+       *      i --     X X
+       *             X X X X
+       *           X X X X X X
+       *)
+      fun lowerTriangle i jMid =
+        Util.for (0, Int.min (height-i, blockHeight)) (fn k =>
+          let
+            val lo = Int.max (0, jMid-k-1)
+            val hi = Int.min (width, jMid+k+1)
+          in
+            Util.for (lo, hi) (fn j => setM (i+k, j))
+          end)
+
+      (* This sets rows [i, i + blockHeight].
+       * Note that this includes the row i+blockHeight; i.e. the number of
+       * rows set is blockHeight+1
+       *)
+      fun setStripStartingAt i =
+        ( ForkJoin.parfor 1 (0, numBlocks) (fn b =>
+            upperTriangle i (b * blockWidth + blockHeight))
+        ; ForkJoin.parfor 1 (0, numBlocks+1) (fn b =>
+            lowerTriangle (i+1) (b * blockWidth))
+        )
+
+      fun loop i =
+        if i >= height then () else
+        ( setStripStartingAt i
+        ; loop (i + blockHeight + 1)
+        )
+    in
+      loop 0
+    end
+
+  (* ====================================================================== *)
+
+  fun isolateMinSeam width height M =
+    let
+      fun idxMin2 ((j1, m1), (j2, m2)) =
+        if m1 > m2 then (j2, m2) else (j1, m1)
+      fun idxMin3 (a, b, c) = idxMin2 (a, idxMin2 (b, c))
+
+      (* the index of the minimum seam in the last row *)
+      val (jMin, _) =
+        SeqBasis.reduce 1000
+          idxMin2 (~1, Real.posInf) (0, width) (fn j => (j, M (height-1, j)))
+
+      val seam = ForkJoin.alloc height
+
+      fun computeSeamBackwards (i, j) =
+        if i = 0 then
+          Array.update (seam, 0, j)
+        else
+          let
+            val (j', _) = idxMin3
+              ( (j,   M (i-1, j  ))
+              , (j-1, M (i-1, j-1))
+              , (j+1, M (i-1, j+1))
+              )
+          in
+            Array.update (seam, i, j);
+            computeSeamBackwards (i-1, j')
+          end
+    in
+      computeSeamBackwards (height-1, jMin);
+      ArraySlice.full seam
+    end
+
+  (* ====================================================================== *)
+
+  structure VSIM = VerticalSeamIndexMap
+
+  fun makeSeamCarveIndex numSeamsToRemove image =
+    let
+      val N = #width image * #height image
+
+      (* This buffer will be reused throughout *)
+      val minSeamEnergies = ForkJoin.alloc N
+
+      fun pixel idx (i, j) = PPM.elem image (VSIM.remap idx (i, j))
+
+      (* ===========================================
+       * computing the energy of all pixels
+       * (gradient values)
+       *)
+
+      fun d p1 p2 = Color.distance (p1, p2)
+
+      fun energy idx (i, j) =
+        let
+          val (h, w) = VSIM.domain idx
+        in
+          if j = w-1 then Real.posInf
+          else if i = h - 1 then 0.0
+          else let
+            val p = pixel idx (i, j)
+            val dx = d p (pixel idx (i, j+1))
+            val dy = d p (pixel idx (i+1, j))
+          in
+            Math.sqrt (dx + dy)
+          end
+        end
+
+      (* ============================================
+       * loop to remove seams
+       *)
+
+      val X = ForkJoin.alloc N
+      val _ = ForkJoin.parfor 4000 (0, N) (fn i => Array.update (X, i, ~1))
+      fun setX (i, j) x = Array.update (X, i*(#width image) + j, x)
+
+      val idx = VSIM.new (#height image, #width image)
+
+      fun loop numSeamsRemoved =
+        if numSeamsRemoved >= numSeamsToRemove then () else
+        let
+          val currentWidth = #width image - numSeamsRemoved
+          val _ = triangularBlockedWriteAllMinSeams
+            currentWidth
+            (#height image)
+            (energy idx)
+            minSeamEnergies (* results written here *)
+
+          fun M (i, j) =
+            if j < 0 orelse j >= currentWidth then Real.posInf
+            else Array.sub (minSeamEnergies, i*currentWidth + j)
+
+          val seam = isolateMinSeam currentWidth (#height image) M
+        in
+          Seq.foreach seam (fn (i, j) =>
+            setX (VSIM.remap idx (i, j)) numSeamsRemoved);
+
+          VSIM.carve idx seam;
+
+          loop (numSeamsRemoved+1)
+        end
+
+    in
+      loop 0;
+
+      ArraySlice.full X
+    end
+
+end

--- a/examples/src/seam-carve/VerticalSeamIndexMap.sml
+++ b/examples/src/seam-carve/VerticalSeamIndexMap.sml
@@ -1,0 +1,80 @@
+structure VerticalSeamIndexMap :>
+sig
+  type t
+  type seam = int Seq.t
+
+  (* `new (height, width)` *)
+  val new: (int * int) -> t
+
+  (* Remaps from some (H, W) into (H', W'). For vertical seams, we always
+   * have H = H'. This signature could be reused for horizontal seams, though.
+   *)
+  val domain: t -> (int * int)
+  val range: t -> (int * int)
+
+  (* Remap an index (i, j) to some (i', j'), where i is a row index and j
+   * is a column index. With vertical seams, i = i'.
+   *)
+  val remap: t -> (int * int) -> (int * int)
+
+  (* Remove the given seam.
+   * Causes all (i, j) on the right of the seam to be remapped to (i, j+1).
+   *)
+  val carve: t -> seam -> unit
+end =
+struct
+
+  structure AS = ArraySlice
+
+  type t = {displacement: int Seq.t, domain: (int * int) ref, range: int * int}
+  type seam = int Seq.t
+
+  fun new (height, width) =
+    { displacement = AS.full (SeqBasis.tabulate 4000 (0, width*height) (fn _ => 0))
+    , domain = ref (height, width)
+    , range = (height, width)
+    }
+
+  fun domain ({domain = ref d, ...}: t) = d
+  fun range ({range=r, ...}: t) = r
+
+  fun remap ({displacement, range=(h, w), ...}: t) (i, j) =
+    (i, j + Seq.nth displacement (i*w + j))
+
+  (* fun carve ({displacement, domain=(h, w), range=r}: t) seam =
+    let
+    in
+      { domain = (h, w-1)
+      , range = r
+      , displacement = displacement
+      }
+    end *)
+
+  fun carve ({displacement, domain=(d as ref (h, w)), range=(_, w0)}: t) seam =
+    ( d := (h, w-1)
+    ; ForkJoin.parfor 1 (0, h) (fn i =>
+        let
+          val s = Seq.nth seam i
+        in
+          Util.for (s+1, w) (fn j =>
+            ArraySlice.update (displacement, i*w0 + j - 1,
+              1 + Seq.nth displacement (i*w0 + j)))
+        end)
+    )
+
+    (* { domain = (h, w-1)
+    , range = (h, w0)
+    , displacement = AS.full (SeqBasis.tabulate 1000 (0, w0*h) (fn k =>
+        let
+          val i = k div w0
+          val j = k mod w0
+          val s = Seq.nth seam i
+        in
+          if j < s then
+            Seq.nth displacement (i*w0 + j)
+          else
+            1 + Seq.nth displacement (i*w0 + j)
+        end))
+    } *)
+
+end

--- a/examples/src/seam-carve/main.sml
+++ b/examples/src/seam-carve/main.sml
@@ -1,0 +1,101 @@
+structure CLA = CommandLineArgs
+
+fun usage () =
+  let
+    val msg =
+      "usage: seam-carve INPUT.ppm [-num-seams N] [-output OUTPUT.gif]\n"
+  in
+    TextIO.output (TextIO.stdErr, msg);
+    OS.Process.exit OS.Process.failure
+  end
+
+val filename =
+  case CLA.positional () of
+    [x] => x
+  | _ => usage ()
+
+val numSeams = CLA.parseInt "num-seams" 100
+val _ = print ("num-seams " ^ Int.toString numSeams ^ "\n")
+
+val (image, tm) = Util.getTime (fn _ => PPM.read filename)
+val _ = print ("read image in " ^ Time.fmt 4 tm ^ "s\n")
+
+val w = #width image
+val h = #height image
+
+val _ = print ("height " ^ Int.toString h ^ "\n")
+val _ = print ("width " ^ Int.toString w ^ "\n")
+
+val _ =
+  if numSeams >= 0 andalso numSeams <= w then ()
+  else
+    Util.die ("cannot remove " ^ Int.toString numSeams
+    ^ " seams from image of width " ^ Int.toString w ^ "\n")
+
+val _ = print "seam carving...\n"
+val (X, tm) = Util.getTime (fn _ => SCI.makeSeamCarveIndex numSeams image)
+val _ = print ("computed seam carving index in " ^ Time.fmt 4 tm ^ "s\n")
+
+val outfile = CLA.parseString "output" ""
+
+val _ =
+  if outfile = "" then
+    print ("use -output XXX.gif to see result\n")
+  else
+    let
+      val ((palette, indices), tm) = Util.getTime (fn _ =>
+        let
+          val palette = GIF.Palette.summarize [Color.black, Color.red] 128 image
+        in
+          (palette, #remap palette image)
+        end)
+
+      val _ = print ("remapped color palette in " ^ Time.fmt 4 tm ^ "s\n")
+      fun getIdx (i, j) = Seq.nth indices (i*w + j)
+
+      val redIdx = GIF.Palette.remapColor palette Color.red
+      val blackIdx = GIF.Palette.remapColor palette Color.black
+
+      fun removeSeams count =
+        let
+          val data = ForkJoin.alloc (w * h)
+          fun set (i, j) x = Array.update (data, i*w + j, x)
+
+          (* compact row i from index j, writing the result at index k *)
+          fun compactRow i j k =
+            if j >= w then
+              Util.for (k, w) (fn kk => set (i, kk) blackIdx)
+            else
+              let
+                val xx = Seq.nth X (i*w + j)
+              in
+                if xx = ~1 orelse xx > count then
+                  ( set (i, k) (getIdx (i, j))
+                  ; compactRow i (j+1) (k+1)
+                  )
+                else if xx = count then
+                  ( set (i, k) redIdx
+                  ; compactRow i (j+1) (k+1)
+                  )
+                else
+                  compactRow i (j+1) k
+              end
+        in
+          ForkJoin.parfor 1 (0, h) (fn i => compactRow i 0 0);
+          ArraySlice.full data
+        end
+
+      val (images, tm) = Util.getTime (fn _ =>
+        ArraySlice.full (SeqBasis.tabulate 1 (0, numSeams+1) removeSeams))
+      val _ = print ("generated images in " ^ Time.fmt 4 tm ^ "s\n")
+
+      val (_, tm) = Util.getTime (fn _ =>
+        GIF.writeMany outfile 10 palette
+          { width = w
+          , height = h
+          , numImages = numSeams+1
+          , getImage = Seq.nth images
+          })
+    in
+      print ("wrote to " ^ outfile ^ " in " ^ Time.fmt 4 tm ^ "s\n")
+    end

--- a/examples/src/seam-carve/sources.mlb
+++ b/examples/src/seam-carve/sources.mlb
@@ -1,0 +1,4 @@
+../../lib/sources.mlb
+VerticalSeamIndexMap.sml
+SCI.sml
+main.sml


### PR DESCRIPTION
Seam carving is an algorithm for "content-aware resizing", allowing an image to be re-scaled while attempting to preserve the interesting features of the image. It works by removing low-energy "seams" (vertical or horizontal paths of pixels) to reduce either the width or height of the image. For more info, see https://en.wikipedia.org/wiki/Seam_carving.

This patch provides a parallel implementation. It can remove as many seams as desired, and can also generate an animation (as a .gif) of the process, showing how the image shrinks gradually as more seams are removed. It's super cool... check it out!

As part of this patch, I also implemented support for generating GIF files. This turned out to be an interesting problem of its own, because GIFs use a custom form of LZW compression. Very tricky to get the bits right...