### PR TITLE
Offband hierarchical heap objects, separate union-find nodes, and epoch-based reclamation

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,8 +17,13 @@ PROGRAMS= \
 	seam-carve
 
 DBG_PROGRAMS := $(addsuffix .dbg,$(PROGRAMS))
+SYSMPL_PROGRAMS := $(addsuffix .sysmpl,$(PROGRAMS))
 
 all: $(PROGRAMS)
+
+all-dbg: $(DBG_PROGRAMS)
+
+all-sysmpl: $(SYSMPL_PROGRAMS)
 
 $(PROGRAMS): %: phony
 	@mkdir -p bin
@@ -30,6 +35,10 @@ $(DBG_PROGRAMS): %.dbg: phony
 	$(MPL) $(FLAGS) $(DBG_FLAGS) -output bin/$*.dbg src/$*/sources.mlb
 	@echo "successfully built bin/$*.dbg"
 
+$(SYSMPL_PROGRAMS): %.sysmpl: phony
+	@mkdir -p bin
+	mpl $(FLAGS) -output bin/$*.sysmpl src/$*/sources.mlb
+	@echo "successfully built bin/$*.sysmpl"
 
 .PHONY: clean phony
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,6 @@
 MPL=../build/bin/mpl
 FLAGS=-default-type int64 -default-type word64
+DBG_FLAGS=-debug true -debug-runtime true -keep g
 
 PROGRAMS= \
 	fib \
@@ -15,12 +16,20 @@ PROGRAMS= \
 	reverb \
 	seam-carve
 
+DBG_PROGRAMS := $(addsuffix .dbg,$(PROGRAMS))
+
 all: $(PROGRAMS)
 
 $(PROGRAMS): %: phony
 	@mkdir -p bin
 	$(MPL) $(FLAGS) -output bin/$* src/$*/sources.mlb
 	@echo "successfully built bin/$*"
+
+$(DBG_PROGRAMS): %.dbg: phony
+	@mkdir -p bin
+	$(MPL) $(FLAGS) $(DBG_FLAGS) -output bin/$*.dbg src/$*/sources.mlb
+	@echo "successfully built bin/$*.dbg"
+
 
 .PHONY: clean phony
 

--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -61,6 +61,7 @@ extern C_Pthread_Key_t gcstate_key;
 #include "gc/heap.c"
 #include "gc/hierarchical-heap.c"
 #include "gc/hierarchical-heap-collection.c"
+#include "gc/hierarchical-heap-ebr.c"
 #include "gc/init-world.c"
 #include "gc/init.c"
 #include "gc/int-inf.c"

--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -50,6 +50,7 @@ extern C_Pthread_Key_t gcstate_key;
 #include "gc/done.c"
 #include "gc/deferred-promote.c"
 #include "gc/enter_leave.c"
+#include "gc/fixed-size-allocator.c"
 #include "gc/foreach.c"
 #include "gc/forward.c"
 #include "gc/frame.c"

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -41,6 +41,7 @@ typedef GC_state GCState_t;
 #include "gc/foreach.h"
 #include "gc/stack.h"
 #include "gc/chunk.h"
+#include "gc/fixed-size-allocator.h"
 #include "gc/thread.h"
 #include "gc/weak.h"
 #include "gc/int-inf.h"

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -80,6 +80,7 @@ typedef GC_state GCState_t;
 #include "gc/parallel.h"
 #include "gc/processor.h"
 #include "gc/hierarchical-heap.h"
+#include "gc/hierarchical-heap-ebr.h"
 #include "gc/hierarchical-heap-collection.h"
 #include "gc/local-scope.h"
 #include "gc/local-heap.h"

--- a/runtime/gc/assign.c
+++ b/runtime/gc/assign.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Sam Westrick
+/* Copyright (C) 2019-2021 Sam Westrick
  * Copyright (C) 1999-2017 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -7,7 +7,7 @@
  * See the file MLton-LICENSE for details.
  */
 
-#define cas(F, O, N) ((__sync_val_compare_and_swap(F, O, N)))
+// #define cas(F, O, N) ((__sync_val_compare_and_swap(F, O, N)))
 
 void Assignable_writeBarrier(GC_state s, objptr dst, objptr* field, objptr src) {
   assert(isObjptr(dst));
@@ -44,95 +44,48 @@ void Assignable_writeBarrier(GC_state s, objptr dst, objptr* field, objptr src) 
     (size_t)(objend - dstp));
 #endif
 
-  /* If src does not reference an object, then no need to check for
-   * down-pointers. */
-
+  HH_EBR_fastLeaveQuiescentState(s);
 
   HM_HierarchicalHeap dstHH = HM_getLevelHeadPathCompress(HM_getChunkOf(dstp));
 
-
   objptr readVal = *field;
   if (dstHH->depth >= 1 && isObjptr(readVal) && s->wsQueueTop!=BOGUS_OBJPTR) {
-    // check for the case where this is laggy
-    // uint64_t topval = *(uint64_t*)objptrToPointer(s->wsQueueTop, NULL);
-    // uint32_t shallowestPrivateLevel = UNPACK_IDX(topval);
-    // uint32_t minDepth = (shallowestPrivateLevel>0)?(shallowestPrivateLevel-1):0;
-    // printf("%d\n", dstHH->depth);
-    // Need to remember for all levels
     pointer currp = objptrToPointer(readVal, NULL);
     HM_HierarchicalHeap currHH = HM_getLevelHead(HM_getChunkOf(currp));
-
-    // bool z = cas(&(dstHH->concurrentPack->isCollecting), false, false);
-    // assert(!z);
-
     if(currHH == dstHH) {
-      // printf("%s\n", "storing this");
       HM_HH_addRootForCollector(dstHH, currp);
     }
-    //   bool saveReadVal = false;
-    //   if(!isCasInst) {
-    //     objptr old = cas(field, readVal, dst);
-
-    //     if(old == readVal){
-    //       // this means the first cas succeeded. Therefore, this write needs to save the pointer.
-    //       saveReadVal = true;
-    //     }
-    //     else {
-    //       while(old!=readVal) {
-    //         readVal = old;
-    //         old = cas(field, readVal, dst);
-    //       }
-    //     }
-    //   }
-
-    //   else {
-    //     objptr old = cas (field, readVal, dst);
-    //   }
-
-    //   //  If the input instruction is a cas, then it must succeed and there is no need to check(?).
-    //   if(saveReadVal || isCasInst) {
-    //     HM_HH_addRootForCollector(srcHH, currp);
-    //   }
   }
 
-
+  /* If src does not reference an object, then no need to check for
+   * down-pointers. */
   if (!isObjptr(src))
-    return;
+    goto writebarrier_done;
 
   pointer srcp = objptrToPointer(src, NULL);
   HM_HierarchicalHeap srcHH = HM_getLevelHeadPathCompress(HM_getChunkOf(srcp));
-  // if (dstHH->depth >= srcHH->depth) {
-  //   if(HM_HH_isCCollecting(srcHH)) {
-  //     if (!CC_isPointerMarked(srcp)) {
-  //       HM_HH_addRootForCollector(srcHH, src);
-  //     }
-  //   }
-  // }
+
   /* Internal or up-pointer. */
-  if (dstHH->depth >= srcHH->depth){
-    return;
-  }
+  if (dstHH->depth >= srcHH->depth)
+    goto writebarrier_done;
 
   /* deque down-pointers are handled separately during collection. */
   if (dst == s->wsQueue)
-    return;
+    goto writebarrier_done;
 
   /* Otherwise, remember the down-pointer! */
   uint32_t d = srcHH->depth;
   GC_thread thread = getThreadCurrent(s);
   HM_HierarchicalHeap hh = HM_HH_getHeapAtDepth(s, thread, d);
-
-  if (hh == NULL)
-  {
-    LOG(LM_HH_PROMOTION, LL_WARNING,
-      "Write down pointer without local hierarchical heap: "FMTOBJPTR " to "FMTOBJPTR,
-      dst, src);
-    return;
-  }
+  assert(NULL != hh);
   HM_rememberAtLevel(hh, dst, field, src);
 
   /* SAM_NOTE: TODO: track bytes allocated here in
    * thread->bytesAllocatedSinceLast...? */
+
+writebarrier_done:
+  HH_EBR_enterQuiescentState(s);
+  return;
 }
 
 // void Assignable_updateBarrier (GC_state s, objptr dst, objptr* field, objptr src) {

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -619,6 +619,13 @@ pointer HM_shiftChunkStart(HM_chunk chunk, size_t bytes) {
   return oldStart;
 }
 
+pointer HM_getChunkStartGap(HM_chunk chunk) {
+  if (0 == chunk->startGap) {
+    return NULL;
+  }
+  return (pointer)chunk + sizeof(struct HM_chunk);
+}
+
 HM_chunk HM_getChunkListLastChunk(HM_chunkList list) {
   if (NULL == list) {
     return NULL;

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -588,7 +588,7 @@ size_t HM_getChunkSize(HM_chunk chunk) {
 }
 
 size_t HM_getChunkSizePastFrontier(HM_chunk chunk) {
-  assert(chunk->frontier < chunk->limit);
+  assert(chunk->frontier <= chunk->limit);
   return (size_t)chunk->limit - (size_t)chunk->frontier;
 }
 

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -650,28 +650,31 @@ size_t HM_getChunkListSize(HM_chunkList list) {
 HM_HierarchicalHeap HM_getLevelHead(HM_chunk chunk) {
   assert(chunk != NULL);
   assert(chunk->levelHead != NULL);
-  HM_HierarchicalHeap cursor = chunk->levelHead;
+  HM_UnionFindNode cursor = chunk->levelHead;
   while (cursor->representative != NULL) {
     cursor = cursor->representative;
   }
-  return cursor;
+  assert(NULL != cursor->payload);
+  return cursor->payload;
 }
 
 HM_HierarchicalHeap HM_getLevelHeadPathCompress(HM_chunk chunk) {
   HM_HierarchicalHeap levelHead = HM_getLevelHead(chunk);
   assert(levelHead != NULL);
+  HM_UnionFindNode topNode = HM_HH_getUFNode(levelHead);
+  assert(topNode != NULL);
 
   /* fast path */
-  if (chunk->levelHead == levelHead) {
+  if (chunk->levelHead == topNode) {
     return levelHead;
   }
 
-  HM_HierarchicalHeap cursor = chunk->levelHead;
-  chunk->levelHead = levelHead;
+  HM_UnionFindNode cursor = chunk->levelHead;
+  chunk->levelHead = topNode;
 
-  while (cursor != levelHead) {
-    HM_HierarchicalHeap representative = cursor->representative;
-    cursor->representative = levelHead;
+  while (cursor != topNode) {
+    HM_UnionFindNode representative = cursor->representative;
+    cursor->representative = topNode;
     cursor = representative;
   }
 

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -228,6 +228,9 @@ pointer HM_getChunkStart(HM_chunk chunk);
  * returns a pointer to the gap, or NULL if no more space is available. */
 pointer HM_shiftChunkStart(HM_chunk chunk, size_t bytes);
 
+/* return the pointer to the start gap, or NULL if it doesn't have a gap. */
+pointer HM_getChunkStartGap(HM_chunk chunk);
+
 /**
  * This function gets the last chunk in a list
  *

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -43,7 +43,7 @@ struct ForwardHHObjptrArgs;
  * levelheads are identical to normal chunks (e.g. they still store user
  * objects in the reserved space up to .frontier). */
 struct HM_chunk {
-  struct HM_HierarchicalHeap *levelHead;
+  struct HM_UnionFindNode *levelHead;
 
   pointer frontier; // end of allocations within this chunk
   pointer limit;    // the end of this chunk

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -470,6 +470,8 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
     .fromHead = (void*) &(origList)
   };
 
+  HH_EBR_enterQuiescentState(s);
+
   // JATIN_NOTE: Some HM_hierarchical objects in origList
   // might not be reachable from the mutator roots.
   // So, I assign the levelHead of all chunks in the list to targetHH.
@@ -628,6 +630,8 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
   }
 
   *(origList) = *(repList);
+
+  HH_EBR_leaveQuiescentState(s);
 
   /** This is safe (no race with any zips), because `targetHH` is split off
     * from the main spine of the program.

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -612,6 +612,15 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
 
   *(origList) = *(repList);
 
+  /** SAM_NOTE: TODO: the following line needs to be included at some point.
+    * The problem at the moment is that the left-most spine task could be
+    * zipping (due to joins) which which modifies the union-find tree for this
+    * representative. This is a race! freeAllDependents modifies the union-find
+    * dependant structure as it goes... It's not safe for this to happen
+    * concurrently with an HH zip.
+    */
+  // HM_HH_freeAllDependants(s, targetHH, TRUE);
+
   HM_assertChunkListInvariants(origList);
 
   timespec_now(&stopTime);

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -616,12 +616,8 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
 
   *(origList) = *(repList);
 
-  /** SAM_NOTE: TODO: the following line needs to be included at some point.
-    * The problem at the moment is that the left-most spine task could be
-    * zipping (due to joins) which which modifies the union-find tree for this
-    * representative. This is a race! freeAllDependents modifies the union-find
-    * dependant structure as it goes... It's not safe for this to happen
-    * concurrently with an HH zip.
+  /** This is safe (no race with any zips), because `targetHH` is split off
+    * from the main spine of the program.
     */
   HM_HH_freeAllDependants(s, targetHH, TRUE);
 

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -479,7 +479,7 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
   }
   else if (baseChunk == (targetHH->chunkList).firstChunk && isConcurrent) {}
   else {
-    assert(0);
+    // assert(0);
   }
 
   // forward down pointers

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -472,15 +472,18 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
     T->levelHead = targetHH;
   }
 
-
-  HM_chunk baseChunk = HM_getChunkOf((void *)targetHH);
-  if(isInScope(baseChunk, &lists)) {
-    saveChunk(baseChunk, &lists);
-  }
-  else if (baseChunk == (targetHH->chunkList).firstChunk && isConcurrent) {}
-  else {
-    // assert(0);
-  }
+  /** SAM_NOTE: This code is no longer needed, because HH objects are not
+    * stored in their own chunks. I'm leaving it commented for now (just for
+    * reference), and will remove later.
+    */
+  // HM_chunk baseChunk = HM_getChunkOf((void *)targetHH);
+  // if(isInScope(baseChunk, &lists)) {
+  //   saveChunk(baseChunk, &lists);
+  // }
+  // else if (baseChunk == (targetHH->chunkList).firstChunk && isConcurrent) {}
+  // else {
+  //   // assert(0);
+  // }
 
   // forward down pointers
   struct HM_chunkList downPtrs;

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -486,7 +486,7 @@ void CC_collectWithRoots(GC_state s, HM_HierarchicalHeap targetHH,
 #endif
     assert(T->tmpHeap == NULL);
     T->tmpHeap = lists.fromHead;
-    T->levelHead = targetHH;
+    T->levelHead = HM_HH_getUFNode(targetHH);
   }
 
   /** SAM_NOTE: This code is no longer needed, because HH objects are not

--- a/runtime/gc/concurrent-collection.h
+++ b/runtime/gc/concurrent-collection.h
@@ -17,8 +17,8 @@
 // #include "logger.h"
 
 
-#if (defined (MLTON_GC_INTERNAL_FUNCS))
-#define LL_Log LL_FORCE
+#if (defined (MLTON_GC_INTERNAL_TYPES))
+
 // Struct to pass around args. repList is the new chunklist.
 typedef struct ConcurrentCollectArgs {
 	HM_chunkList origList;
@@ -51,6 +51,16 @@ typedef struct ConcurrentPackage {
 	size_t bytesSurvivedLastCollection;
 	struct HM_chunkList remSet;
 } * ConcurrentPackage;
+
+#else
+
+struct ConcurrentPackage;
+typedef struct ConcurrentPackage *ConcurrentPackage;
+
+#endif
+
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 // Assume complete access in this function
 // This function constructs a HM_chunkList of reachable chunks without copying them

--- a/runtime/gc/concurrent-collection.h
+++ b/runtime/gc/concurrent-collection.h
@@ -47,9 +47,17 @@ typedef struct ConcurrentPackage {
 	bool shouldCollect;
 	enum CCState ccstate;
 	objptr stack;
+
+  /** For deciding when to collect. Could be cleaned up.
+    */
 	size_t bytesAllocatedSinceLastCollection;
 	size_t bytesSurvivedLastCollection;
-	struct HM_chunkList remSet;
+
+  /** To avoid races with other processor adding to the remset (writebarrier or
+    * promotions).
+    */
+	// struct HM_chunkList remSet;
+
 } * ConcurrentPackage;
 
 #else

--- a/runtime/gc/concurrent-stack.h
+++ b/runtime/gc/concurrent-stack.h
@@ -1,7 +1,7 @@
 #ifndef CC_STACK_H
 #define CC_STACK_H
 
-#if (defined (MLTON_GC_INTERNAL_FUNCS))
+#if (defined (MLTON_GC_INTERNAL_TYPES))
 
 typedef struct CC_stack {
     size_t size;
@@ -11,6 +11,15 @@ typedef struct CC_stack {
     pthread_mutex_t mutex;
 }
 CC_stack;
+
+#else
+
+struct CC_stack;
+typedef struct CC_stack CC_stack;
+
+#endif /* MLTON_GC_INTERNAL_TYPES */
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 void CC_stack_init(CC_stack* stack, size_t capacity);
 
@@ -32,5 +41,6 @@ void forEachObjptrinStack(GC_state s,
                           GC_foreachObjptrFun f,
                           void* rawArgs);
 
+#endif /* MLTON_GC_INTERNAL_FUNCS */
+
 #endif /* CC_STACK_H */
-#endif

--- a/runtime/gc/deferred-promote.c
+++ b/runtime/gc/deferred-promote.c
@@ -229,7 +229,9 @@ void promoteDownPtr(__attribute__((unused)) GC_state s,
   }
 
   if (NULL == args->fromSpace[args->toDepth]) {
-    /* note that new heaps are initialized with a free chunk. */
+    /** Now that copying objects lazily allocates chunks, we don't rely
+      * on fresh chunk here.
+      */
     HM_HierarchicalHeap newhh = HM_HH_new(s, args->toDepth);
     args->fromSpace[args->toDepth] = newhh;
   }

--- a/runtime/gc/done.c
+++ b/runtime/gc/done.c
@@ -56,6 +56,21 @@ static void displayHHAllocStats(FILE *out, GC_state s) {
   fprintf(out, "current hh alloc capacity: %zu\n", currentFixedSizeCapacity(fsa));
   fprintf(out, "current hh space util: %.1f%%\n",
           100.0 * currentFixedSizeSpaceUtilization(fsa));
+
+  size_t maxSize = 0;
+  size_t maxHeight = 0;
+  for (HM_HierarchicalHeap cursor = getHierarchicalHeapCurrent(s);
+       cursor != NULL;
+       cursor = cursor->nextAncestor)
+  {
+    if (cursor->numDependants > maxSize)
+      maxSize = cursor->numDependants;
+    if (cursor->heightDependants > maxHeight) maxHeight =
+      cursor->heightDependants;
+  }
+
+  fprintf(out, "current max num hh dependants: %zu\n", maxSize);
+  fprintf(out, "current max dependant tree height: %zu\n", maxHeight);
 }
 
 

--- a/runtime/gc/done.c
+++ b/runtime/gc/done.c
@@ -47,6 +47,17 @@ static void displayGlobalCumulativeStatistics (
     //          uintmaxToCommaString (ChunkPool_maxAllocated ()));
 }
 
+static void displayHHAllocStats(FILE *out, GC_state s) {
+  FixedSizeAllocator fsa = getHHAllocator(s);
+  fprintf(out, "num hh allocated: %zu\n", numFixedSizeAllocated(fsa));
+  fprintf(out, "num hh freed: %zu\n", numFixedSizeFreed(fsa));
+  fprintf(out, "num hh shared freed: %zu\n", numFixedSizeSharedFreed(fsa));
+  fprintf(out, "num hh currently in use: %zu\n", numFixedSizeCurrentlyInUse(fsa));
+  fprintf(out, "current hh alloc capacity: %zu\n", currentFixedSizeCapacity(fsa));
+  fprintf(out, "current hh space util: %.1f%%\n",
+          100.0 * currentFixedSizeSpaceUtilization(fsa));
+}
+
 
 static void displayCumulativeStatistics (FILE *out, struct GC_cumulativeStatistics *cumulativeStatistics) {
   struct rusage ru_total;
@@ -203,10 +214,12 @@ void GC_done(GC_state s) {
           displayCumulativeStatistics
               (s->controls->summaryFile,
                s->procStates[proc].cumulativeStatistics);
+          displayHHAllocStats(s->controls->summaryFile, &(s->procStates[proc]));
         }
       } else {
         displayCumulativeStatistics(s->controls->summaryFile,
                                     s->cumulativeStatistics);
+        displayHHAllocStats(s->controls->summaryFile, s);
       }
     } else if (JSON == s->controls->summaryFormat) {
       displayCumulativeStatisticsJSON(s->controls->summaryFile, s);

--- a/runtime/gc/fixed-size-allocator.c
+++ b/runtime/gc/fixed-size-allocator.c
@@ -14,8 +14,9 @@ void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize) {
   return;
 }
 
+
 void* allocateFixedSize(FixedSizeAllocator fsa) {
-  // Fast path: if the freelist has a top element, just use that!
+  // Fast path #1: if the fast local freelist has a top element, just use that!
   if (NULL != fsa->freeList) {
     struct FixedSizeElement *elem = fsa->freeList;
     fsa->freeList = elem->nextFree;
@@ -23,11 +24,33 @@ void* allocateFixedSize(FixedSizeAllocator fsa) {
     return (void*)elem;
   }
 
+  /** Fast path #2: clear the shared list, if it's non-empty. We return the
+    * top element, and all other elements from the shared list go into the
+    * fast local freelist.
+    *
+    * SAM_NOTE: I'm pretty sure this doesn't suffer from ABA? The shared
+    * freelist is essentially a Treiber stack, which (when popping) can suffer
+    * from ABA. But in this scenario, pops are serialized against new
+    * allocations, which would be the only source of ABA.
+    */
+  if (NULL != fsa->sharedFreeList) {
+    struct FixedSizeElement *topElem = fsa->sharedFreeList;
+    while (true) {
+      if (__sync_bool_compare_and_swap(&(fsa->sharedFreeList), topElem, NULL))
+        break;
+      topElem = fsa->sharedFreeList;
+    }
+    assert(NULL != topElem);
+    struct FixedSizeElement *otherElems = topElem->nextFree;
+    fsa->freeList = otherElems;
+    topElem->nextFree = NULL;
+    return (void*)topElem;
+  }
+
+  // Fast path #3: bump space on the buffer, if we can.
+
   HM_chunk chunk = HM_getChunkListLastChunk(&(fsa->buffer));
 
-  /** Secondary fast path: if enough space at the frontier of the buffer,
-    * then bump the pointer.
-    */
   if (NULL != chunk && HM_getChunkSizePastFrontier(chunk) >= fsa->fixedSize) {
     pointer elem = chunk->frontier;
     chunk->frontier += fsa->fixedSize;
@@ -37,8 +60,16 @@ void* allocateFixedSize(FixedSizeAllocator fsa) {
 
   /** Slow path: not enough space in the buffer, so we need to allocate a new
     * chunk. Note that this case implicitly handles the (chunk == NULL) case.
+    *
+    * When we allocate a new chunk, we include a pointer (in the start gap)
+    * to the containing allocator. This makes it easy to "return" freed objects
+    * to their original buffer, by looking up the chunk header.
     */
-  chunk = HM_allocateChunk(&(fsa->buffer), fsa->fixedSize);
+
+  chunk = HM_allocateChunk(&(fsa->buffer), fsa->fixedSize + sizeof(void*));
+  pointer gap = HM_shiftChunkStart(chunk, sizeof(void*));
+  *(FixedSizeAllocator *)gap = fsa;
+
   assert(NULL != chunk && HM_getChunkSizePastFrontier(chunk) >= fsa->fixedSize);
   pointer elem = chunk->frontier;
   chunk->frontier += fsa->fixedSize;
@@ -46,11 +77,27 @@ void* allocateFixedSize(FixedSizeAllocator fsa) {
   return elem;
 }
 
-void freeFixedSize(FixedSizeAllocator fsa, void* arg) {
+
+void freeFixedSize(FixedSizeAllocator myfsa, void* arg) {
+  HM_chunk chunk = HM_getChunkOf((pointer)arg);
+  pointer gap = HM_getChunkStartGap(chunk);
+  FixedSizeAllocator owner = (FixedSizeAllocator)gap;
   struct FixedSizeElement *elem = arg;
-  elem->nextFree = fsa->freeList;
-  fsa->freeList = elem;
-  return;
+
+  /** Fast path! When I own the object, just use the fast free-list. */
+  if (myfsa == owner) {
+    elem->nextFree = myfsa->freeList;
+    myfsa->freeList = elem;
+    return;
+  }
+
+  /** Slow path: concurrent insertion into shared freelist. */
+  while (true) {
+    struct FixedSizeElement *oldVal = owner->sharedFreeList;
+    elem->nextFree = oldVal;
+    if (__sync_bool_compare_and_swap(&(owner->sharedFreeList), oldVal, elem))
+      break;
+  }
 }
 
 #endif

--- a/runtime/gc/fixed-size-allocator.c
+++ b/runtime/gc/fixed-size-allocator.c
@@ -11,6 +11,7 @@ void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize) {
   fsa->fixedSize = align(fixedSize < minSize ? minSize : fixedSize, 8);
   HM_initChunkList(&(fsa->buffer));
   fsa->freeList = NULL;
+  fsa->sharedFreeList = NULL;
   return;
 }
 

--- a/runtime/gc/fixed-size-allocator.c
+++ b/runtime/gc/fixed-size-allocator.c
@@ -1,0 +1,56 @@
+/* Copyright (C) 2021 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize) {
+  size_t minSize = sizeof(struct FixedSizeElement);
+  fsa->fixedSize = align(fixedSize < minSize ? minSize : fixedSize, 8);
+  HM_initChunkList(&(fsa->buffer));
+  fsa->freeList = NULL;
+  return;
+}
+
+void* allocateFixedSize(FixedSizeAllocator fsa) {
+  // Fast path: if the freelist has a top element, just use that!
+  if (NULL != fsa->freeList) {
+    struct FixedSizeElement *elem = fsa->freeList;
+    fsa->freeList = elem->nextFree;
+    elem->nextFree = NULL;
+    return (void*)elem;
+  }
+
+  HM_chunk chunk = HM_getChunkListLastChunk(&(fsa->buffer));
+
+  /** Secondary fast path: if enough space at the frontier of the buffer,
+    * then bump the pointer.
+    */
+  if (NULL != chunk && HM_getChunkSizePastFrontier(chunk) >= fsa->fixedSize) {
+    pointer elem = chunk->frontier;
+    chunk->frontier += fsa->fixedSize;
+    assert(chunk->frontier <= chunk->limit);
+    return elem;
+  }
+
+  /** Slow path: not enough space in the buffer, so we need to allocate a new
+    * chunk. Note that this case implicitly handles the (chunk == NULL) case.
+    */
+  chunk = HM_allocateChunk(&(fsa->buffer), fsa->fixedSize);
+  assert(NULL != chunk && HM_getChunkSizePastFrontier(chunk) >= fsa->fixedSize);
+  pointer elem = chunk->frontier;
+  chunk->frontier += fsa->fixedSize;
+  assert(chunk->frontier <= chunk->limit);
+  return elem;
+}
+
+void freeFixedSize(FixedSizeAllocator fsa, void* arg) {
+  struct FixedSizeElement *elem = arg;
+  elem->nextFree = fsa->freeList;
+  fsa->freeList = elem;
+  return;
+}
+
+#endif

--- a/runtime/gc/fixed-size-allocator.h
+++ b/runtime/gc/fixed-size-allocator.h
@@ -1,0 +1,51 @@
+/* Copyright (C) 2021 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#ifndef _FIXED_SIZE_ARENA_H_
+#define _FIXED_SIZE_ARENA_H_
+
+#if (defined (MLTON_GC_INTERNAL_TYPES))
+
+struct FixedSizeElement {
+  struct FixedSizeElement *nextFree;
+};
+
+typedef struct FixedSizeAllocator {
+  /** The size of each element.
+    * Must be >= sizeof(struct FixedSizeElement), because when an object is
+    * deallocated, that space is reuse to hold a freelist of free elements.
+    */
+  size_t fixedSize;
+
+  /** A bit of a hack. I just want quick access to pages to store elements.
+    * I'll reuse the frontier mechanism inherent to chunks to remember which
+    * portions of chunks are currently in use by the allocator.
+    */
+  struct HM_chunkList buffer;
+
+  struct FixedSizeElement *freeList;
+
+} *FixedSizeAllocator;
+
+#else
+
+struct FixedSizeAllocator;
+typedef struct FixedSizeAllocator *FixedSizeAllocator;
+
+#endif
+
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize);
+void* allocateFixedSize(FixedSizeAllocator fsa);
+void freeFixedSize(FixedSizeAllocator fsa, void* elem);
+
+#endif
+
+
+
+#endif // _FIXED_SIZE_ARENA_H_

--- a/runtime/gc/fixed-size-allocator.h
+++ b/runtime/gc/fixed-size-allocator.h
@@ -20,6 +20,16 @@ typedef struct FixedSizeAllocator {
     */
   size_t fixedSize;
 
+  /** Some statistics. Can calculate e.g.
+    *   numFreed = numLocalFreed + numSharedFreed
+    *   numCurrentlyInUse = numAllocated - numFreed
+    *   currentCapacity = totalSize(buffer) / fixedSize
+    *   spaceUtilization = numCurrentlyInUse / currentCapacity
+    */
+  size_t numAllocated;
+  size_t numLocalFreed;
+  size_t numSharedFreed;
+
   /** A bit of a hack. I just want quick access to pages to store elements.
     * I'll reuse the frontier mechanism inherent to chunks to remember which
     * portions of chunks are currently in use by the allocator. Also, the
@@ -81,6 +91,16 @@ void* allocateFixedSize(FixedSizeAllocator fsa);
   * allocated, freeing will be fast!
   */
 void freeFixedSize(FixedSizeAllocator myfsa, void* elem);
+
+
+size_t numFixedSizeAllocated(FixedSizeAllocator fsa);
+size_t numFixedSizeFreed(FixedSizeAllocator fsa);
+size_t numFixedSizeSharedFreed(FixedSizeAllocator fsa);
+size_t numFixedSizeCurrentlyInUse(FixedSizeAllocator fsa);
+size_t currentFixedSizeCapacity(FixedSizeAllocator fsa);
+double currentFixedSizeSpaceUtilization(FixedSizeAllocator fsa);
+
+void displayFixedSizeStatistics(FILE *out, FixedSizeAllocator fsa);
 
 #endif
 

--- a/runtime/gc/fixed-size-allocator.h
+++ b/runtime/gc/fixed-size-allocator.h
@@ -22,11 +22,24 @@ typedef struct FixedSizeAllocator {
 
   /** A bit of a hack. I just want quick access to pages to store elements.
     * I'll reuse the frontier mechanism inherent to chunks to remember which
-    * portions of chunks are currently in use by the allocator.
+    * portions of chunks are currently in use by the allocator. Also, the
+    * startGap mechanism is nice for adding some additional metadata...
     */
   struct HM_chunkList buffer;
 
+  /** The fast free-list, which is not-safe-for-concurrency.
+    */
   struct FixedSizeElement *freeList;
+
+  /** The slow free-list, which is safe-for-concurrency. (When someone else
+    * owns an object, we have to use this list, because the
+    * owner's allocator could concurrently be in use.)
+    *
+    * TODO: flat-combining for these frees? I.e. use a bump-buffer of elements
+    * returned, and then when a new allocation request comes in, move all of
+    * these elements to the fast free list.
+    */
+  struct FixedSizeElement *sharedFreeList;
 
 } *FixedSizeAllocator;
 
@@ -40,9 +53,34 @@ typedef struct FixedSizeAllocator *FixedSizeAllocator;
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
+/** Initialize [fsa] to be able to allocate objects of size [fixedSize].
+  * You should never re-initialize an allocator.
+  */
 void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize);
+
+
+/** Allocate an object of the size specified when the allocator was initialized.
+  * Thread-safe, as long as the [fsa]'s given as argument are distinct.
+  * (But two concurrent threads should NOT allocate from the same [fsa] at the
+  * same time.)
+  */
 void* allocateFixedSize(FixedSizeAllocator fsa);
-void freeFixedSize(FixedSizeAllocator fsa, void* elem);
+
+
+/** Free [elem]. Standard assumptions: [elem] must have been returned by some
+  * call to [allocateFixedSize], and don't double-free!
+  *
+  * This function "returns" the allocated space to its original allocator. This
+  * is safe for concurrency, i.e. two concurrent threads are allowed to
+  * simultaneously free two different elements which where allocated by the
+  * same allocator.
+  *
+  * The argument [myfsa] is for improved performance. If [elem] belongs to
+  * [myfsa], it will be pushed onto the fast (not-safe-for-concurrency)
+  * free-list. This way, if a processor frees an object that it itself
+  * allocated, freeing will be fast!
+  */
+void freeFixedSize(FixedSizeAllocator myfsa, void* elem);
 
 #endif
 

--- a/runtime/gc/fixed-size-allocator.h
+++ b/runtime/gc/fixed-size-allocator.h
@@ -100,8 +100,6 @@ size_t numFixedSizeCurrentlyInUse(FixedSizeAllocator fsa);
 size_t currentFixedSizeCapacity(FixedSizeAllocator fsa);
 double currentFixedSizeSpaceUtilization(FixedSizeAllocator fsa);
 
-void displayFixedSizeStatistics(FILE *out, FixedSizeAllocator fsa);
-
 #endif
 
 

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -108,7 +108,6 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   // CC_collectWithRoots(s, )
 
   endAtomic(s);
-  HH_EBR_enterQuiescentState(s);
 
   Trace0(EVENT_RUNTIME_LEAVE);
 }

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -84,7 +84,6 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed(s);
   getThreadCurrent(s)->exnStack = s->exnStack;
   beginAtomic(s);
-
   HH_EBR_leaveQuiescentState(s);
 
   assert(getThreadCurrent(s)->hierarchicalHeap != NULL);
@@ -109,6 +108,7 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   // CC_collectWithRoots(s, )
 
   endAtomic(s);
+  HH_EBR_enterQuiescentState(s);
 
   Trace0(EVENT_RUNTIME_LEAVE);
 }

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -85,6 +85,8 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   getThreadCurrent(s)->exnStack = s->exnStack;
   beginAtomic(s);
 
+  HH_EBR_leaveQuiescentState(s);
+
   assert(getThreadCurrent(s)->hierarchicalHeap != NULL);
   assert(threadAndHeapOkay(s));
 

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -53,7 +53,7 @@ void growStackCurrent(GC_state s) {
   }
   assert(stackSize < HM_getChunkSizePastFrontier(newChunk));
   newChunk->mightContainMultipleObjects = FALSE;
-  newChunk->levelHead = hh;
+  newChunk->levelHead = HM_HH_getUFNode(hh);
 
   pointer frontier = HM_getChunkFrontier(newChunk);
   assert(frontier == HM_getChunkStart(newChunk));

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -65,6 +65,10 @@ struct FixedSizeAllocator* getHHAllocator(GC_state s) {
   return &(s->hhAllocator);
 }
 
+struct FixedSizeAllocator* getUFAllocator(GC_state s) {
+  return &(s->hhUnionFindAllocator);
+}
+
 
 struct HM_chunkList* getFreeListLarge(GC_state s) {
   return &(s->freeListLarge);

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -61,6 +61,10 @@ struct HM_chunkList* HM_getsharedFreeList(GC_state s)  {
   return s->sharedfreeList;
 }
 
+struct FixedSizeAllocator* getHHAllocator(GC_state s) {
+  return &(s->hhAllocator);
+}
+
 
 struct HM_chunkList* getFreeListLarge(GC_state s) {
   return &(s->freeListLarge);

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -51,6 +51,7 @@ struct GC_state {
   objptr *globals;
   uint32_t globalsLength;
   struct FixedSizeAllocator hhAllocator;
+  struct FixedSizeAllocator hhUnionFindAllocator;
   struct HH_EBR_shared * hhEBR;
   struct GC_lastMajorStatistics *lastMajorStatistics;
   pointer limitPlusSlop; /* limit + GC_HEAP_LIMIT_SLOP */

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -50,6 +50,7 @@ struct GC_state {
   /* Ordinary globals */
   objptr *globals;
   uint32_t globalsLength;
+  struct FixedSizeAllocator hhAllocator;
   struct GC_lastMajorStatistics *lastMajorStatistics;
   pointer limitPlusSlop; /* limit + GC_HEAP_LIMIT_SLOP */
   int (*loadGlobals)(FILE *f); /* loads the globals from the file. */
@@ -101,6 +102,8 @@ static inline struct HM_chunkList* getFreeListExtraSmall(GC_state s);
 static inline struct HM_chunkList* getFreeListSmall(GC_state s);
 static inline struct HM_chunkList* getFreeListLarge(GC_state s);
 struct HM_chunkList* HM_getsharedFreeList(GC_state s);
+
+static inline struct FixedSizeAllocator* getHHAllocator(GC_state s);
 
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -51,6 +51,7 @@ struct GC_state {
   objptr *globals;
   uint32_t globalsLength;
   struct FixedSizeAllocator hhAllocator;
+  struct HH_EBR_shared * hhEBR;
   struct GC_lastMajorStatistics *lastMajorStatistics;
   pointer limitPlusSlop; /* limit + GC_HEAP_LIMIT_SLOP */
   int (*loadGlobals)(FILE *f); /* loads the globals from the file. */

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -360,8 +360,9 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
 #endif
 
     HM_appendChunkList(getFreeListSmall(s), level);
-
+    HM_HH_freeAllDependants(s, hhTail);
     freeFixedSize(getHHAllocator(s), hhTail);
+
     hhTail = nextAncestor;
   }
 

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -360,7 +360,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
 #endif
 
     HM_appendChunkList(getFreeListSmall(s), level);
-    HM_HH_freeAllDependants(s, hhTail);
+    HM_HH_freeAllDependants(s, hhTail, FALSE);
     freeFixedSize(getHHAllocator(s), hhTail);
 
     hhTail = nextAncestor;

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -361,6 +361,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
 
     HM_appendChunkList(getFreeListSmall(s), level);
     HM_HH_freeAllDependants(s, hhTail, FALSE);
+    freeFixedSize(getUFAllocator(s), HM_HH_getUFNode(hhTail));
     freeFixedSize(getHHAllocator(s), hhTail);
 
     hhTail = nextAncestor;
@@ -378,7 +379,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
   }
 
   /* merge in toSpace */
-  hh = HM_HH_zip(hhTail, hhToSpace);
+  hh = HM_HH_zip(s, hhTail, hhToSpace);
   thread->hierarchicalHeap = hh;
 
   /* update currentChunk and associated */
@@ -542,7 +543,7 @@ objptr relocateObject(
     HM_chunk chunk = HM_getChunkOf(p);
     HM_unlinkChunk(HM_HH_getChunkList(HM_getLevelHead(chunk)), chunk);
     HM_appendChunk(tgtChunkList, chunk);
-    chunk->levelHead = tgtHeap;
+    chunk->levelHead = HM_HH_getUFNode(tgtHeap);
 
     LOG(LM_HH_COLLECTION, LL_DEBUGMORE,
       "Moved single-object chunk %p of size %zu",
@@ -747,7 +748,7 @@ pointer copyObject(pointer p,
     if (NULL == chunk) {
       DIE("Ran out of space for Hierarchical Heap!");
     }
-    chunk->levelHead = tgtHeap;
+    chunk->levelHead = HM_HH_getUFNode(tgtHeap);
   }
 
   pointer frontier = HM_getChunkFrontier(chunk);

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -693,8 +693,9 @@ void forwardHHObjptr (GC_state s,
 
     HM_HierarchicalHeap tgtHeap = args->toSpace[opDepth];
     if (tgtHeap == NULL) {
-      /* Level does not exist, so create it */
-      /* SAM_NOTE: new heaps are initialized with one free chunk. */
+      /** Level does not exist, so create it. Relocating an object allocates
+        * chunks lazily, so we don't need a fresh chunk here.
+        */
       tgtHeap = HM_HH_new(s, opDepth);
       args->toSpace[opDepth] = tgtHeap;
     }

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -359,10 +359,9 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
     }
 #endif
 
-    /* This implicitly frees the heap records too, because they are stored in
-     * the level list. */
     HM_appendChunkList(getFreeListSmall(s), level);
 
+    freeFixedSize(getHHAllocator(s), hhTail);
     hhTail = nextAncestor;
   }
 

--- a/runtime/gc/hierarchical-heap-ebr.c
+++ b/runtime/gc/hierarchical-heap-ebr.c
@@ -39,6 +39,10 @@ static inline void setAnnouncement(GC_state s, uint32_t pid, size_t ann) {
   s->hhEBR->announce[ANNOUNCEMENT_PADDING*pid] = ann;
 }
 
+void HH_EBR_enterQuiescentState(GC_state s) {
+  uint32_t mypid = s->procNumber;
+  setAnnouncement(s, mypid, SET_Q_TRUE(getAnnouncement(s, mypid)));
+}
 
 static void rotateAndReclaim(GC_state s) {
   HH_EBR_shared ebr = s->hhEBR;

--- a/runtime/gc/hierarchical-heap-ebr.c
+++ b/runtime/gc/hierarchical-heap-ebr.c
@@ -1,0 +1,139 @@
+/* Copyright (C) 2021 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+/** Some helper stuff, if we use DEBRA later instead of regular EBR.
+  * DEBRA uses an additional "quiescent bit", where each process
+  * not only announces its current epoch, but also whether or not it is
+  * currently quiescent. This optimization is useful for identifying
+  * grace periods, but is not essential.
+  */
+#if 0
+#define PACK(epoch, qbit) ((((size_t)(epoch)) << 1) | ((qbit) & 1))
+#define UNPACK_EPOCH(announcement) ((announcement) >> 1)
+#define UNPACK_QBIT(announcement) ((announcement) & 1)
+
+#define SET_Q_TRUE(announcement) ((announcement) | (size_t)1)
+#define SET_Q_FALSE(announcement) ((announcement) & (~(size_t)1))
+#endif
+
+
+void HH_EBR_init(GC_state s) {
+  HH_EBR_shared ebr = malloc(sizeof(struct HH_EBR_shared));
+
+  ebr->epoch = 0;
+  ebr->announce = malloc(s->numberOfProcs * sizeof(size_t));
+  ebr->local = malloc(s->numberOfProcs * sizeof(struct HH_EBR_local));
+
+  for (uint32_t i = 0; i < s->numberOfProcs; i++) {
+    // Everyone starts by announcing epoch = 0
+    ebr->announce[i] = 0;
+    for (int j = 0; j < 3; j++)
+      HM_initChunkList(&(ebr->local[i].limboBags[j]));
+  }
+
+  s->hhEBR = ebr;
+}
+
+
+void HH_EBR_enterQuiescentState(__attribute__((unused)) GC_state s) {
+  /** SAM_NOTE: no-op for now. Not needed for normal EBR. But later if we
+    * use DEBRA, we need to set the quiescent bit.
+    */
+  return;
+}
+
+
+void HH_EBR_leaveQuiescentState(GC_state s) {
+  HH_EBR_shared ebr = s->hhEBR;
+  uint32_t mypid = s->procNumber;
+  uint32_t numProcs = s->numberOfProcs;
+
+  size_t globalEpoch = ebr->epoch;
+  size_t myAnnouncement = ebr->announce[mypid];
+  assert(globalEpoch == myAnnouncement || globalEpoch == myAnnouncement+1);
+
+  if (myAnnouncement != globalEpoch) {
+    /** Advance into the current epoch. To do so, we need to clear the limbo
+      * bag of the epoch we're moving into.
+      */
+
+    int limboIdx = globalEpoch % 3;
+    HM_chunkList limboBag = &(ebr->local[mypid].limboBags[limboIdx]);
+
+    // Free all HH records in the limbo bag.
+    for (HM_chunk chunk = HM_getChunkListFirstChunk(limboBag);
+         NULL != chunk;
+         chunk = chunk->nextChunk)
+    {
+      for (pointer p = HM_getChunkStart(chunk);
+           p < HM_getChunkFrontier(chunk);
+           p += sizeof(HM_HierarchicalHeap *))
+      {
+        freeFixedSize(getHHAllocator(s), *(HM_HierarchicalHeap*)p);
+      }
+    }
+
+    HM_appendChunkList(getFreeListSmall(s), limboBag);
+    HM_initChunkList(limboBag); // clear it out
+
+    ebr->announce[mypid] = globalEpoch;
+  }
+
+  // Check: has everyone entered the current global epoch?
+  bool everyoneInSameEpoch = TRUE;
+  for (uint32_t otherpid = 0; otherpid < numProcs; otherpid++) {
+    if (ebr->announce[otherpid] != globalEpoch) {
+      everyoneInSameEpoch = FALSE;
+      break;
+    }
+  }
+
+  if (everyoneInSameEpoch && (ebr->epoch == globalEpoch)) {
+    __sync_val_compare_and_swap(&(ebr->epoch), globalEpoch, globalEpoch+1);
+  }
+
+}
+
+
+void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh) {
+  HH_EBR_shared ebr = s->hhEBR;
+  uint32_t mypid = s->procNumber;
+  size_t epoch = ebr->announce[mypid];
+  int limboIdx = epoch % 3;
+  HM_chunkList limboBag = &(ebr->local[mypid].limboBags[limboIdx]);
+  HM_chunk chunk = HM_getChunkListLastChunk(limboBag);
+
+  // fast path: bump frontier in chunk
+
+  if (NULL != chunk &&
+      HM_getChunkSizePastFrontier(chunk) >= sizeof(HM_HierarchicalHeap *))
+  {
+    pointer p = chunk->frontier;
+    *(HM_HierarchicalHeap *)p = hh;
+    chunk->frontier += sizeof(HM_HierarchicalHeap *);
+    assert(chunk->limit >= chunk->frontier);
+    return;
+  }
+
+  // slow path: allocate new chunk
+
+  chunk = HM_allocateChunk(limboBag, sizeof(HM_HierarchicalHeap *));
+
+  assert(NULL != chunk &&
+    HM_getChunkSizePastFrontier(chunk) >= sizeof(HM_HierarchicalHeap *));
+
+  pointer p = chunk->frontier;
+  *(HM_HierarchicalHeap *)p = hh;
+  chunk->frontier += sizeof(HM_HierarchicalHeap *);
+  assert(chunk->limit >= chunk->frontier);
+  return;
+}
+
+
+
+#endif // MLTON_GC_INTERNAL_FUNCS

--- a/runtime/gc/hierarchical-heap-ebr.c
+++ b/runtime/gc/hierarchical-heap-ebr.c
@@ -6,20 +6,54 @@
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-/** Some helper stuff, if we use DEBRA later instead of regular EBR.
-  * DEBRA uses an additional "quiescent bit", where each process
-  * not only announces its current epoch, but also whether or not it is
-  * currently quiescent. This optimization is useful for identifying
-  * grace periods, but is not essential.
-  */
-#if 0
 #define PACK(epoch, qbit) ((((size_t)(epoch)) << 1) | ((qbit) & 1))
 #define UNPACK_EPOCH(announcement) ((announcement) >> 1)
 #define UNPACK_QBIT(announcement) ((announcement) & 1)
 
 #define SET_Q_TRUE(announcement) ((announcement) | (size_t)1)
 #define SET_Q_FALSE(announcement) ((announcement) & (~(size_t)1))
-#endif
+
+
+static inline bool getQBit(GC_state s, uint32_t pid) {
+  size_t ann = s->hhEBR->announce[pid];
+  return UNPACK_QBIT(ann);
+}
+
+static inline void setQBitTrue(GC_state s, uint32_t pid) {
+  size_t ann = s->hhEBR->announce[pid];
+  s->hhEBR->announce[pid] = SET_Q_TRUE(ann);
+}
+
+static inline void setQBitFalse(GC_state s, uint32_t pid) {
+  size_t ann = s->hhEBR->announce[pid];
+  s->hhEBR->announce[pid] = SET_Q_FALSE(ann);
+}
+
+
+static void rotateAndReclaim(GC_state s) {
+  HH_EBR_shared ebr = s->hhEBR;
+  uint32_t mypid = s->procNumber;
+
+  int limboIdx = (ebr->local[mypid].limboIdx + 1) % 3;
+  ebr->local[mypid].limboIdx = limboIdx;
+  HM_chunkList limboBag = &(ebr->local[mypid].limboBags[limboIdx]);
+
+  // Free all HH records in the limbo bag.
+  for (HM_chunk chunk = HM_getChunkListFirstChunk(limboBag);
+       NULL != chunk;
+       chunk = chunk->nextChunk)
+  {
+    for (pointer p = HM_getChunkStart(chunk);
+         p < HM_getChunkFrontier(chunk);
+         p += sizeof(HM_HierarchicalHeap *))
+    {
+      freeFixedSize(getHHAllocator(s), *(HM_HierarchicalHeap*)p);
+    }
+  }
+
+  HM_appendChunkList(getFreeListSmall(s), limboBag);
+  HM_initChunkList(limboBag); // clear it out
+}
 
 
 void HH_EBR_init(GC_state s) {
@@ -30,8 +64,9 @@ void HH_EBR_init(GC_state s) {
   ebr->local = malloc(s->numberOfProcs * sizeof(struct HH_EBR_local));
 
   for (uint32_t i = 0; i < s->numberOfProcs; i++) {
-    // Everyone starts by announcing epoch = 0
-    ebr->announce[i] = 0;
+    // Everyone starts by announcing epoch = 0, and starts in quiescent state
+    ebr->announce[i] = PACK(0, 1);
+    ebr->local[i].limboIdx = 0;
     for (int j = 0; j < 3; j++)
       HM_initChunkList(&(ebr->local[i].limboBags[j]));
   }
@@ -40,13 +75,24 @@ void HH_EBR_init(GC_state s) {
 }
 
 
-void HH_EBR_enterQuiescentState(__attribute__((unused)) GC_state s) {
-  /** SAM_NOTE: no-op for now. Not needed for normal EBR. But later if we
-    * use DEBRA, we need to set the quiescent bit.
-    */
-  return;
+void HH_EBR_enterQuiescentState(GC_state s) {
+  setQBitTrue(s, s->procNumber);
 }
 
+void HH_EBR_fastLeaveQuiescentState(GC_state s) {
+  HH_EBR_shared ebr = s->hhEBR;
+  uint32_t mypid = s->procNumber;
+  size_t globalEpoch = ebr->epoch;
+  size_t myEpoch = UNPACK_EPOCH(ebr->announce[mypid]);
+  assert(globalEpoch >= myEpoch);
+  if (myEpoch != globalEpoch) {
+    /** Advance into the current epoch. To do so, we need to clear the limbo
+      * bag of the epoch we're moving into.
+      */
+    rotateAndReclaim(s);
+  }
+  ebr->announce[mypid] = PACK(globalEpoch, 0);
+}
 
 void HH_EBR_leaveQuiescentState(GC_state s) {
   HH_EBR_shared ebr = s->hhEBR;
@@ -54,57 +100,39 @@ void HH_EBR_leaveQuiescentState(GC_state s) {
   uint32_t numProcs = s->numberOfProcs;
 
   size_t globalEpoch = ebr->epoch;
-  size_t myAnnouncement = ebr->announce[mypid];
-  assert(globalEpoch == myAnnouncement || globalEpoch == myAnnouncement+1);
+  size_t myEpoch = UNPACK_EPOCH(ebr->announce[mypid]);
+  assert(globalEpoch >= myEpoch);
 
-  if (myAnnouncement != globalEpoch) {
+  if (myEpoch != globalEpoch) {
     /** Advance into the current epoch. To do so, we need to clear the limbo
       * bag of the epoch we're moving into.
       */
-
-    int limboIdx = globalEpoch % 3;
-    HM_chunkList limboBag = &(ebr->local[mypid].limboBags[limboIdx]);
-
-    // Free all HH records in the limbo bag.
-    for (HM_chunk chunk = HM_getChunkListFirstChunk(limboBag);
-         NULL != chunk;
-         chunk = chunk->nextChunk)
-    {
-      for (pointer p = HM_getChunkStart(chunk);
-           p < HM_getChunkFrontier(chunk);
-           p += sizeof(HM_HierarchicalHeap *))
-      {
-        freeFixedSize(getHHAllocator(s), *(HM_HierarchicalHeap*)p);
-      }
-    }
-
-    HM_appendChunkList(getFreeListSmall(s), limboBag);
-    HM_initChunkList(limboBag); // clear it out
-
-    ebr->announce[mypid] = globalEpoch;
+    rotateAndReclaim(s);
   }
 
   // Check: has everyone entered the current global epoch?
-  bool everyoneInSameEpoch = TRUE;
+  bool everyoneInSameEpochOrQuiescent = TRUE;
   for (uint32_t otherpid = 0; otherpid < numProcs; otherpid++) {
-    if (ebr->announce[otherpid] != globalEpoch) {
-      everyoneInSameEpoch = FALSE;
+    if ( !(UNPACK_EPOCH(ebr->announce[otherpid]) == globalEpoch
+           || getQBit(s, otherpid)) )
+    {
+      everyoneInSameEpochOrQuiescent = FALSE;
       break;
     }
   }
 
-  if (everyoneInSameEpoch && (ebr->epoch == globalEpoch)) {
+  if (everyoneInSameEpochOrQuiescent && (ebr->epoch == globalEpoch)) {
     __sync_val_compare_and_swap(&(ebr->epoch), globalEpoch, globalEpoch+1);
   }
 
+  ebr->announce[mypid] = PACK(globalEpoch, 0);
 }
 
 
 void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh) {
   HH_EBR_shared ebr = s->hhEBR;
   uint32_t mypid = s->procNumber;
-  size_t epoch = ebr->announce[mypid];
-  int limboIdx = epoch % 3;
+  int limboIdx = ebr->local[mypid].limboIdx;
   HM_chunkList limboBag = &(ebr->local[mypid].limboBags[limboIdx]);
   HM_chunk chunk = HM_getChunkListLastChunk(limboBag);
 

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -42,7 +42,7 @@ typedef struct HH_EBR_shared * HH_EBR_shared;
 
 void HH_EBR_init(GC_state s);
 void HH_EBR_leaveQuiescentState(GC_state s);
-void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh);
+void HH_EBR_retire(GC_state s, HM_UnionFindNode hhuf);
 
 #endif // MLTON_GC_INTERNAL_FUNCS
 

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -15,6 +15,7 @@
 struct HH_EBR_local {
   struct HM_chunkList limboBags[3];
   int limboIdx;
+  uint32_t checkNext;
 };
 
 // There is exactly one of these! Everyone shares a reference to it.
@@ -40,10 +41,7 @@ typedef struct HH_EBR_shared * HH_EBR_shared;
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 void HH_EBR_init(GC_state s);
-void HH_EBR_enterQuiescentState(GC_state s);
 void HH_EBR_leaveQuiescentState(GC_state s);
-void HH_EBR_fastLeaveQuiescentState(GC_state s);
-
 void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh);
 
 #endif // MLTON_GC_INTERNAL_FUNCS

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -16,7 +16,7 @@ struct HH_EBR_local {
   struct HM_chunkList limboBags[3];
   int limboIdx;
   uint32_t checkNext;
-};
+} __attribute__((aligned(128)));
 
 // There is exactly one of these! Everyone shares a reference to it.
 typedef struct HH_EBR_shared {

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -14,6 +14,7 @@
 
 struct HH_EBR_local {
   struct HM_chunkList limboBags[3];
+  int limboIdx;
 };
 
 // There is exactly one of these! Everyone shares a reference to it.
@@ -21,6 +22,7 @@ typedef struct HH_EBR_shared {
   size_t epoch;
 
   // announcement array, length = num procs
+  // each announcement is packed: 63 bits for epoch, 1 bit for quiescent bit
   size_t *announce;
 
   // processor-local data, length = num procs
@@ -40,6 +42,7 @@ typedef struct HH_EBR_shared * HH_EBR_shared;
 void HH_EBR_init(GC_state s);
 void HH_EBR_enterQuiescentState(GC_state s);
 void HH_EBR_leaveQuiescentState(GC_state s);
+void HH_EBR_fastLeaveQuiescentState(GC_state s);
 
 void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh);
 

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -1,0 +1,49 @@
+/* Copyright (C) 2021 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+/** Epoch-based reclamation (EBR) of hierarchical heap records.
+  */
+
+#ifndef HIERARCHICAL_HEAP_EBR_H_
+#define HIERARCHICAL_HEAP_EBR_H_
+
+#if (defined (MLTON_GC_INTERNAL_TYPES))
+
+struct HH_EBR_local {
+  struct HM_chunkList limboBags[3];
+};
+
+// There is exactly one of these! Everyone shares a reference to it.
+typedef struct HH_EBR_shared {
+  size_t epoch;
+
+  // announcement array, length = num procs
+  size_t *announce;
+
+  // processor-local data, length = num procs
+  struct HH_EBR_local *local;
+} * HH_EBR_shared;
+
+#else
+
+struct HH_EBR_local;
+struct HH_EBR_shared;
+typedef struct HH_EBR_shared * HH_EBR_shared;
+
+#endif // MLTON_GC_INTERNAL_TYPES
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+void HH_EBR_init(GC_state s);
+void HH_EBR_enterQuiescentState(GC_state s);
+void HH_EBR_leaveQuiescentState(GC_state s);
+
+void HH_EBR_retire(GC_state s, HM_HierarchicalHeap hh);
+
+#endif // MLTON_GC_INTERNAL_FUNCS
+
+
+#endif // HIERARCHICAL_HEAP_EBR_H_

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -41,6 +41,7 @@ typedef struct HH_EBR_shared * HH_EBR_shared;
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 void HH_EBR_init(GC_state s);
+void HH_EBR_enterQuiescentState(GC_state s);
 void HH_EBR_leaveQuiescentState(GC_state s);
 void HH_EBR_retire(GC_state s, HM_UnionFindNode hhuf);
 

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -654,7 +654,11 @@ void HM_HH_addRootForCollector(HM_HierarchicalHeap hh, pointer p) {
 }
 
 
-void HM_HH_freeAllDependants(GC_state s, HM_HierarchicalHeap hh) {
+void HM_HH_freeAllDependants(
+  GC_state s,
+  HM_HierarchicalHeap hh,
+  bool retireInsteadOfFree)
+{
   FixedSizeAllocator myHHAllocator = getHHAllocator(s);
 
   HM_HierarchicalHeap parent = hh;
@@ -704,8 +708,14 @@ void HM_HH_freeAllDependants(GC_state s, HM_HierarchicalHeap hh) {
       if (child->dependant1 == NULL) {
         // free and jump to other grandchild
         HM_HierarchicalHeap grandchild = child->dependant2;
-        freeFixedSize(myHHAllocator, child);
+
+        if (retireInsteadOfFree) {
+          HH_EBR_retire(s, child);
+        } else {
+          freeFixedSize(myHHAllocator, child);
+        }
         numFreed++;
+
         child = grandchild;
       }
       else {

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -390,9 +390,10 @@ void HM_HH_forceLeftHeap(
   endAtomic(s);
 }
 
-// Separate the list into two. The "fromList" will be garbage-collected
-// but the chunkList is not touched by CC.
-// It can be used by the mutator for promotions or other allocations.
+/** Migrate all chunks of the thread's HH into the side heap (subHeapForRootCC),
+  * used for concurrent collection. Also allocate a fresh hierarchical heap
+  * for the thread.
+  */
 void mergeHeapForRootCC(GC_state s, GC_thread thread) {
   HM_HierarchicalHeap hh = thread->hierarchicalHeap;
   HM_HierarchicalHeap subhh = hh->subHeapForRootCC;

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -18,7 +18,16 @@ typedef struct HM_HierarchicalHeap {
   uint32_t depth;
 
   struct HM_chunkList chunkList;
-  struct HM_chunkList fromList;
+  // struct HM_chunkList fromList;
+
+  /** This is a bit of a hack. For root (fully concurrent) collections,
+    * we need to separate collected space from the space where new allocations
+    * are permitted. Really, all we need is just a separate chunklist (and
+    * this is what Jatin originally implemented). But for tracking HH objects
+    * and their union-find dependants, having a completely separate HH object
+    * is nice because then we can free dependants during root CC.
+    */
+  struct HM_HierarchicalHeap *subHeapForRootCC;
 
   struct HM_chunkList rememberedSet;
   struct ConcurrentPackage concurrentPack;
@@ -80,10 +89,10 @@ static inline HM_chunkList HM_HH_getChunkList(HM_HierarchicalHeap hh)
   return &(hh->chunkList);
 }
 
-static inline HM_chunkList HM_HH_getFromList(HM_HierarchicalHeap hh)
-{
-  return &(hh->fromList);
-}
+// static inline HM_chunkList HM_HH_getFromList(HM_HierarchicalHeap hh)
+// {
+//   return &(hh->fromList);
+// }
 
 
 static inline HM_chunkList HM_HH_getRemSet(HM_HierarchicalHeap hh)

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018,2019 Sam Westrick
+/* Copyright (C) 2018-2021 Sam Westrick
  * Copyright (C) 2014,2015 Ram Raghunathan.
  *
  * MLton is released under a HPND-style license.
@@ -18,7 +18,6 @@ typedef struct HM_HierarchicalHeap {
   uint32_t depth;
 
   struct HM_chunkList chunkList;
-  // struct HM_chunkList fromList;
 
   /** This is a bit of a hack. For root (fully concurrent) collections,
     * we need to separate collected space from the space where new allocations
@@ -88,12 +87,6 @@ static inline HM_chunkList HM_HH_getChunkList(HM_HierarchicalHeap hh)
 {
   return &(hh->chunkList);
 }
-
-// static inline HM_chunkList HM_HH_getFromList(HM_HierarchicalHeap hh)
-// {
-//   return &(hh->fromList);
-// }
-
 
 static inline HM_chunkList HM_HH_getRemSet(HM_HierarchicalHeap hh)
 {

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -21,7 +21,7 @@ typedef struct HM_HierarchicalHeap {
   struct HM_chunkList fromList;
 
   struct HM_chunkList rememberedSet;
-  struct ConcurrentPackage* concurrentPack;
+  struct ConcurrentPackage concurrentPack;
 
   /* The next non-empty ancestor heap. This may skip over "unused" levels.
    * Also, all threads have their own leaf-to-root path (essentially, path
@@ -40,6 +40,11 @@ typedef struct HM_HierarchicalHeap *HM_HierarchicalHeap;
 #endif /* MLTON_GC_INTERNAL_TYPES */
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+static inline ConcurrentPackage HM_HH_getConcurrentPack(HM_HierarchicalHeap hh)
+{
+  return &(hh->concurrentPack);
+}
 
 static inline HM_chunkList HM_HH_getChunkList(HM_HierarchicalHeap hh)
 {

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -130,13 +130,20 @@ void HM_HH_resetList(pointer threadp);
 
 
 /** Very fancy (constant-space) loop that frees each dependant of hh.
-  * Specifically, calls this on each dependant d:
+  * Specifically, calls this on each dependant dhh:
   *
-  *   freeFixedSize(getHHAllocator(s), d)
+  *   freeFixedSize(getHHAllocator(s), dhh)
+  *
+  * Or, if specified to retire instead:
+  *
+  *   HH_EBR_retire(s, dhh);
   *
   * Note that this does NOT free hh.
   */
-void HM_HH_freeAllDependants(GC_state s, HM_HierarchicalHeap hh);
+void HM_HH_freeAllDependants(
+  GC_state s,
+  HM_HierarchicalHeap hh,
+  bool retireInsteadOfFree);
 
 
 #endif /* MLTON_GC_INTERNAL_FUNCS */

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -422,6 +422,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   HM_initChunkList(s->sharedfreeList);
   s->freeListLock = (bool*) (malloc(sizeof(bool)));
   *(s->freeListLock) = false;
+  initFixedSizeAllocator(getHHAllocator(s), sizeof(struct HM_HierarchicalHeap));
 
   s->signalHandlerThread = BOGUS_OBJPTR;
   s->signalsInfo.amInSignalHandler = FALSE;
@@ -538,6 +539,7 @@ void GC_duplicate (GC_state d, GC_state s) {
   HM_initChunkList(getFreeListSmall(d));
   HM_initChunkList(getFreeListLarge(d));
   HM_initChunkList(getFreeListExtraSmall(d));
+  initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap));
   d->sharedfreeList = s->sharedfreeList;
   d->freeListLock = s->freeListLock;
   d->nextChunkAllocSize = s->nextChunkAllocSize;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -506,6 +506,8 @@ void GC_lateInit (GC_state s) {
   /* this has to happen AFTER pthread_setspecific for the main thread */
   HM_configChunks(s);
 
+  HH_EBR_init(s);
+
   s->nextChunkAllocSize = s->controls->allocChunkSize;
 
   /* Initialize profiling.  This must occur after processing
@@ -540,6 +542,7 @@ void GC_duplicate (GC_state d, GC_state s) {
   HM_initChunkList(getFreeListLarge(d));
   HM_initChunkList(getFreeListExtraSmall(d));
   initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap));
+  d->hhEBR = s->hhEBR;
   d->sharedfreeList = s->sharedfreeList;
   d->freeListLock = s->freeListLock;
   d->nextChunkAllocSize = s->nextChunkAllocSize;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -423,6 +423,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->freeListLock = (bool*) (malloc(sizeof(bool)));
   *(s->freeListLock) = false;
   initFixedSizeAllocator(getHHAllocator(s), sizeof(struct HM_HierarchicalHeap));
+  initFixedSizeAllocator(getUFAllocator(s), sizeof(struct HM_UnionFindNode));
 
   s->signalHandlerThread = BOGUS_OBJPTR;
   s->signalsInfo.amInSignalHandler = FALSE;
@@ -542,6 +543,7 @@ void GC_duplicate (GC_state d, GC_state s) {
   HM_initChunkList(getFreeListLarge(d));
   HM_initChunkList(getFreeListExtraSmall(d));
   initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap));
+  initFixedSizeAllocator(getUFAllocator(d), sizeof(struct HM_UnionFindNode));
   d->hhEBR = s->hhEBR;
   d->sharedfreeList = s->sharedfreeList;
   d->freeListLock = s->freeListLock;

--- a/runtime/gc/new-object.c
+++ b/runtime/gc/new-object.c
@@ -140,8 +140,8 @@ GC_thread newThreadWithHeap(GC_state s, size_t reserved, uint32_t depth) {
   if (NULL == sChunk || NULL == tChunk) {
     DIE("Ran out of space for thread+stack allocation!");
   }
-  tChunk->levelHead = hh;
-  sChunk->levelHead = hh;
+  tChunk->levelHead = HM_HH_getUFNode(hh);
+  sChunk->levelHead = HM_HH_getUFNode(hh);
   sChunk->mightContainMultipleObjects = FALSE;
 
   assert(threadSize < HM_getChunkSizePastFrontier(tChunk));

--- a/runtime/gc/new-object.c
+++ b/runtime/gc/new-object.c
@@ -135,12 +135,12 @@ GC_thread newThreadWithHeap(GC_state s, size_t reserved, uint32_t depth) {
    * yet. */
   HM_HierarchicalHeap hh = HM_HH_new(s, depth);
 
-  /* note that new heaps are initialized with one free chunk */
-  HM_chunk tChunk = HM_getChunkListFirstChunk(HM_HH_getChunkList(hh));
+  HM_chunk tChunk = HM_allocateChunk(HM_HH_getChunkList(hh), threadSize);
   HM_chunk sChunk = HM_allocateChunk(HM_HH_getChunkList(hh), stackSize);
-  if (NULL == sChunk) {
-    DIE("Ran out of space for stack allocation!");
+  if (NULL == sChunk || NULL == tChunk) {
+    DIE("Ran out of space for thread+stack allocation!");
   }
+  tChunk->levelHead = hh;
   sChunk->levelHead = hh;
   sChunk->mightContainMultipleObjects = FALSE;
 


### PR DESCRIPTION
In the runtime, hierarchical heaps are represented by `struct HM_HierarchicalHeap`, which we typically call "hh objects". This patch implements special memory management for hh objects, allocating them off-band instead of inside heap chunks directly.

(Some background: previously, hh objects were stored in a "start gap" in the first chunk in the heap. See #104 for more info. The advantage of doing it this way is that garbage hh objects can be implicitly collected during scavenging collection. However, there are a number of disadvantages: each heap always needs at least one chunk, and we can't reclaim any chunk that might have an hh object stored in its start gap, even if that chunk is otherwise entirely unused. This patch eliminates these problems.)

I've made a number of changes:
  - The `struct ConcurrentPackage` component of hh objects is now flattened into the hh directly, rather than being separately allocated.
  - For root concurrent collections, there is now a separate hh object specifically for the scope of the collection. This eliminates some redundancy between `ConcurrentPackage` and `HM_HierarchicalHeap`, and also simplifies some invariants.
  - HH objects are now separate from union-find nodes (`struct HM_UnionFindNode`). Each root in the union-find tree has a corresponding hh object (it's "payload"), but all other union-find nodes don't have payloads. This saves space, because hh objects are much larger than union-find nodes, and now can be eagerly deallocated at heap merges.
  - Both hh objects and union-find nodes are allocated with a new `FixedSizeAllocator` (FSA) mechanism. FSAs are capable of efficiently allocating and freeing objects of a fixed size (chosen when the allocator is initialized). In an FSA, allocations must be single-threaded but freeing is safe for concurrency. The intent is that each processor has its own FSA for a particular type. When an object is freed, it is returned to the FSA that originally allocated that object. (NOTE: this could be improved, perhaps e.g. Hoard-style freelist sharing.)
  - Root union-find nodes keep track of their entire tree of "dependents" (i.e. other union-find nodes in the same set that are not the root). This lets us enumerate the set of dependents of a root node, which is necessary for reclamation. This aspect is described in more detail in [runtime/gc/hierarchical-heap.h](https://github.com/shwestrick/mpl/blob/8f1eba9ff8a37f94eb0b68d65060786d4483f791/runtime/gc/hierarchical-heap.h#L20-L42).
  - To reclaim garbage union-find nodes (those that have been spliced-out due to path-compression), there are two different strategies:
      * For local (copying) collections, we scavenge new hh objects and throw away the old union-find tree by traversing all dependents and directly freeing them.
      * For concurrent collections, we forcibly splice-out all dependents by fully path-compressing (this requires touching every chunk in the heap, which we do anyway for CC). Then, we **retire** each dependent via **epoch-based reclamation**.  Retiring a node puts the node into a limbo state, where it is kept around until a suitable moment in the future can be determined for actual reclamation. This is necessary because other processes could be concurrently traversing the union-find tree while we are attempting to free it.

For the epoch-based reclamation of union-find nodes, I implemented something inspired by Trevor Brown's DEBRA [1,2]. The difference between my implementation and DEBRA is that I assume the typical state for processors is non-quiescent. This is more efficient, because write-barriers are non-quiescent and common.

[1] https://www.cs.utoronto.ca/~tabrown/debra/paper.podc15.pdf
[2] https://arxiv.org/abs/1712.01044v1