### PR TITLE
Parallelize the CC stack (forgotten set)

### DIFF
--- a/runtime/gc/assign.c
+++ b/runtime/gc/assign.c
@@ -107,7 +107,9 @@ void Assignable_writeBarrier(
     pointer currp = objptrToPointer(readVal, NULL);
     HM_HierarchicalHeap currHH = HM_getLevelHead(HM_getChunkOf(currp));
     if (currHH->depth == dstHH->depth
-        && HM_HH_getConcurrentPack(currHH)->ccstate != CC_UNREG) {
+        && HM_HH_getConcurrentPack(currHH)->ccstate != CC_UNREG
+        && !CC_isPointerMarked(currp))
+    {
       HM_HH_addRootForCollector(s, currHH, currp);
     }
   }

--- a/runtime/gc/assign.c
+++ b/runtime/gc/assign.c
@@ -106,15 +106,9 @@ void Assignable_writeBarrier(
   if (dstHH->depth >= 1 && isObjptr(readVal) && s->wsQueueTop!=BOGUS_OBJPTR) {
     pointer currp = objptrToPointer(readVal, NULL);
     HM_HierarchicalHeap currHH = HM_getLevelHead(HM_getChunkOf(currp));
-    if (currHH->depth == dstHH->depth) {
-    // if(currHH == dstHH) {
-      assert(currHH->depth == 1 || (currHH == dstHH));
-      // printf("old pointer tracked dst="FMTPTR" old="FMTPTR" new="FMTPTR". currHH == dstHH? %d\n",
-      //   (uintptr_t)dstp,
-      //   (uintptr_t)currp,
-      //   (uintptr_t)src,
-      //   currHH == dstHH);
-      HM_HH_addRootForCollector(currHH, currp);
+    if (currHH->depth == dstHH->depth
+        && HM_HH_getConcurrentPack(currHH)->ccstate != CC_UNREG) {
+      HM_HH_addRootForCollector(s, currHH, currp);
     }
   }
 

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -83,7 +83,7 @@ void CC_initStack(GC_state s, ConcurrentPackage cp) {
   }
 
   CC_stack* temp  = (struct CC_stack*) malloc(sizeof(struct CC_stack));
-  CC_stack_init(s, temp, 2);
+  CC_stack_init(s, temp);
   cp->rootList = temp;
 }
 
@@ -97,15 +97,15 @@ void CC_addToStack (GC_state s, ConcurrentPackage cp, pointer p) {
   CC_stack_push(s, cp->rootList, (void*)p);
 }
 
-void CC_clearStack(ConcurrentPackage cp) {
+void CC_clearStack(GC_state s, ConcurrentPackage cp) {
   if(cp->rootList!=NULL) {
-    CC_stack_clear(cp->rootList);
+    CC_stack_clear(s, cp->rootList);
   }
 }
 
-void CC_freeStack(ConcurrentPackage cp) {
+void CC_freeStack(GC_state s, ConcurrentPackage cp) {
   if(cp->rootList!=NULL) {
-    CC_stack_free(cp->rootList);
+    CC_stack_free(s, cp->rootList);
     free(cp->rootList);
     cp->rootList = NULL;
   }

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -111,6 +111,12 @@ void CC_freeStack(ConcurrentPackage cp) {
   }
 }
 
+void CC_closeStack(ConcurrentPackage cp) {
+  if (cp->rootList != NULL) {
+    CC_stack_close(cp->rootList);
+  }
+}
+
 bool CC_isPointerMarked (pointer p) {
   return ((MARK_MASK & getHeader (p)) == MARK_MASK);
 }
@@ -981,6 +987,8 @@ size_t CC_collectWithRoots(
     * from the main spine of the program.
     */
   HM_HH_freeAllDependants(s, targetHH, TRUE);
+
+  CC_closeStack(cp);
 
   HM_assertChunkListInvariants(origList);
 

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -76,25 +76,25 @@ void CC_writeFreeChunkInfo(
 }
 
 
-void CC_initStack(ConcurrentPackage cp) {
+void CC_initStack(GC_state s, ConcurrentPackage cp) {
   // don't re-initialize
   if(cp->rootList!=NULL) {
     return;
   }
 
   CC_stack* temp  = (struct CC_stack*) malloc(sizeof(struct CC_stack));
-  CC_stack_init(temp, 2);
+  CC_stack_init(s, temp, 2);
   cp->rootList = temp;
 }
 
-void CC_addToStack (ConcurrentPackage cp, pointer p) {
+void CC_addToStack (GC_state s, ConcurrentPackage cp, pointer p) {
   if(cp->rootList==NULL) {
     // Its NULL because we won't collect this heap. so no need to snapshot
     return;
     // LOG(LM_HH_COLLECTION, LL_FORCE, "Concurrent Stack is not initialised\n");
     // CC_initStack(cp);
   }
-  CC_stack_push(cp->rootList, (void*)p);
+  CC_stack_push(s, cp->rootList, (void*)p);
 }
 
 void CC_clearStack(ConcurrentPackage cp) {

--- a/runtime/gc/concurrent-collection.h
+++ b/runtime/gc/concurrent-collection.h
@@ -90,8 +90,8 @@ PRIVATE void GC_updateObjectHeader(GC_state s, pointer p, GC_header newHeader);
 size_t CC_collectWithRoots(GC_state s, struct HM_HierarchicalHeap * targetHH, GC_thread thread);
 
 void CC_collectAtPublicLevel(GC_state s, GC_thread thread, uint32_t depth);
-void CC_addToStack(ConcurrentPackage cp, pointer p);
-void CC_initStack(ConcurrentPackage cp);
+void CC_addToStack(GC_state s, ConcurrentPackage cp, pointer p);
+void CC_initStack(GC_state s, ConcurrentPackage cp);
 
 
 bool CC_isPointerMarked (pointer p);

--- a/runtime/gc/concurrent-stack.h
+++ b/runtime/gc/concurrent-stack.h
@@ -10,6 +10,7 @@ typedef struct CC_stack_data {
 } CC_stack_data;
 
 typedef struct CC_stack {
+  bool allClosed;
   size_t numStacks;
   struct CC_stack_data *stacks;
 } CC_stack;
@@ -33,13 +34,25 @@ bool CC_stack_push(GC_state s, CC_stack* stack, void* datum);
 void CC_stack_free(GC_state s, CC_stack* stack);
 void CC_stack_clear(GC_state s, CC_stack* stack);
 
-// Prevent further pushes
-void CC_stack_close(CC_stack* stack);
+/** Try to close it, to prevent further pushes. This only works if the bag is
+  * empty. If non-empty, a batch of elements are removed and put into the
+  * given list. Return value indicates whether or not the close was successful
+  */
+bool CC_stack_try_close(CC_stack* stack, HM_chunkList removed);
 
-void forEachObjptrinStack(GC_state s,
-                          CC_stack* stack,
-                          GC_foreachObjptrFun f,
-                          void* rawArgs);
+// Prevent further pushes
+// void CC_stack_close(CC_stack* stack);
+
+void forEachObjptrInCCStackBag(
+  GC_state s,
+  HM_chunkList storage,
+  GC_foreachObjptrFun f,
+  void* rawArgs);
+
+// void forEachObjptrinStack(GC_state s,
+//                           CC_stack* stack,
+//                           GC_foreachObjptrFun f,
+//                           void* rawArgs);
 
 #endif /* MLTON_GC_INTERNAL_FUNCS */
 

--- a/runtime/gc/concurrent-stack.h
+++ b/runtime/gc/concurrent-stack.h
@@ -8,6 +8,7 @@ typedef struct CC_stack_data {
     size_t capacity;
     // The actual array holding the data of the stack.
     void** storage;
+    bool isClosed;
     pthread_mutex_t mutex;
 } CC_stack_data;
 
@@ -34,6 +35,9 @@ bool CC_stack_push(GC_state s, CC_stack* stack, void* datum);
 
 void CC_stack_free(CC_stack* stack);
 void CC_stack_clear(CC_stack* stack);
+
+// Prevent further pushes
+void CC_stack_close(CC_stack* stack);
 
 void forEachObjptrinStack(GC_state s,
                           CC_stack* stack,

--- a/runtime/gc/concurrent-stack.h
+++ b/runtime/gc/concurrent-stack.h
@@ -3,16 +3,23 @@
 
 #if (defined (MLTON_GC_INTERNAL_TYPES))
 
-typedef struct CC_stack {
+typedef struct CC_stack_data {
     size_t size;
     size_t capacity;
     // The actual array holding the data of the stack.
     void** storage;
     pthread_mutex_t mutex;
-}
-CC_stack;
+} CC_stack_data;
+
+typedef struct CC_stack {
+  size_t numStacks;
+  struct CC_stack_data *stacks;
+} CC_stack;
 
 #else
+
+struct CC_stack_data;
+typedef struct CC_stack_data CC_stack_data;
 
 struct CC_stack;
 typedef struct CC_stack CC_stack;
@@ -21,17 +28,9 @@ typedef struct CC_stack CC_stack;
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-void CC_stack_init(CC_stack* stack, size_t capacity);
+void CC_stack_init(GC_state s, CC_stack* stack, size_t capacity);
 
-bool CC_stack_push(CC_stack* stack, void* datum);
-
-void* CC_stack_top(CC_stack* stack);
-
-void* CC_stack_pop(CC_stack* stack);
-
-size_t CC_stack_size(CC_stack* stack);
-
-size_t CC_stack_capacity(CC_stack* stack);
+bool CC_stack_push(GC_state s, CC_stack* stack, void* datum);
 
 void CC_stack_free(CC_stack* stack);
 void CC_stack_clear(CC_stack* stack);

--- a/runtime/gc/concurrent-stack.h
+++ b/runtime/gc/concurrent-stack.h
@@ -4,10 +4,7 @@
 #if (defined (MLTON_GC_INTERNAL_TYPES))
 
 typedef struct CC_stack_data {
-    size_t size;
-    size_t capacity;
-    // The actual array holding the data of the stack.
-    void** storage;
+    struct HM_chunkList storage;
     bool isClosed;
     pthread_mutex_t mutex;
 } CC_stack_data;
@@ -29,12 +26,12 @@ typedef struct CC_stack CC_stack;
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-void CC_stack_init(GC_state s, CC_stack* stack, size_t capacity);
+void CC_stack_init(GC_state s, CC_stack* stack);
 
 bool CC_stack_push(GC_state s, CC_stack* stack, void* datum);
 
-void CC_stack_free(CC_stack* stack);
-void CC_stack_clear(CC_stack* stack);
+void CC_stack_free(GC_state s, CC_stack* stack);
+void CC_stack_clear(GC_state s, CC_stack* stack);
 
 // Prevent further pushes
 void CC_stack_close(CC_stack* stack);

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -953,7 +953,7 @@ Bool HM_HH_registerCont(pointer kl, pointer kr, pointer k, pointer threadp) {
   HM_HH_updateValues(getThreadCurrent(s), s->frontier);
 
   HM_HierarchicalHeap hh = thread->hierarchicalHeap;
-  CC_initStack(HM_HH_getConcurrentPack(hh));
+  CC_initStack(s, HM_HH_getConcurrentPack(hh));
 
   mergeCompletedCCs(s, hh);
   assert(thread->hierarchicalHeap == hh);
@@ -1001,7 +1001,7 @@ Bool HM_HH_registerCont(pointer kl, pointer kr, pointer k, pointer threadp) {
   // HM_HH_getConcurrentPack(hh)->ccstate = CC_REG;
 
   splitHeapForCC(s, thread);
-  CC_initStack(HM_HH_getConcurrentPack(thread->hierarchicalHeap));
+  CC_initStack(s, HM_HH_getConcurrentPack(thread->hierarchicalHeap));
   assert(thread->hierarchicalHeap->subHeapForCC == hh);
 
   HM_assertChunkListInvariants(HM_HH_getChunkList(hh));
@@ -1126,10 +1126,10 @@ bool HM_HH_isCCollecting(HM_HierarchicalHeap hh) {
   return false;
 }
 
-void HM_HH_addRootForCollector(HM_HierarchicalHeap hh, pointer p) {
+void HM_HH_addRootForCollector(GC_state s, HM_HierarchicalHeap hh, pointer p) {
   assert(hh!=NULL);
   if(HM_HH_getConcurrentPack(hh)!=NULL){
-    CC_addToStack(HM_HH_getConcurrentPack(hh), p);
+    CC_addToStack(s, HM_HH_getConcurrentPack(hh), p);
   }
 }
 

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -236,7 +236,7 @@ HM_HierarchicalHeap HM_HH_zip(
 
       // This has to happen before linkInto (which frees hh2)
       HM_HierarchicalHeap hh2anc = hh2->nextAncestor;
-
+      CC_freeStack(HM_HH_getConcurrentPack(hh2));
       linkInto(s, hh1, hh2);
 
       *cursor = hh1;
@@ -739,6 +739,7 @@ void mergeCompletedCCs(GC_state s, HM_HierarchicalHeap hh) {
         HM_HH_getConcurrentPack(completed)->bytesSurvivedLastCollection;
       HM_appendChunkList(HM_HH_getChunkList(hh), HM_HH_getChunkList(completed));
       HM_appendChunkList(HM_HH_getRemSet(hh), HM_HH_getRemSet(completed));
+      CC_freeStack(HM_HH_getConcurrentPack(completed));
       linkInto(s, hh, completed);
       completed = next;
     }
@@ -885,6 +886,7 @@ pointer HM_HH_getRoot(ARG_USED_FOR_ASSERT pointer threadp) {
 
 // ============================================================================
 
+#if 0
 void HM_HH_cancelCC(GC_state s, pointer threadp, pointer hhp) {
   HM_HierarchicalHeap heap = (HM_HierarchicalHeap)hhp;
   GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));
@@ -936,6 +938,14 @@ void HM_HH_cancelCC(GC_state s, pointer threadp, pointer hhp) {
 
   assertCCChainInvariants(mainhh);
   return;
+}
+#endif
+
+void HM_HH_cancelCC(GC_state s, pointer threadp, pointer hhp) {
+  (void)s;
+  (void)threadp;
+  (void)hhp;
+  DIE("HM_HH_cancelCC deprecated");
 }
 
 

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -236,7 +236,7 @@ HM_HierarchicalHeap HM_HH_zip(
 
       // This has to happen before linkInto (which frees hh2)
       HM_HierarchicalHeap hh2anc = hh2->nextAncestor;
-      CC_freeStack(HM_HH_getConcurrentPack(hh2));
+      CC_freeStack(s, HM_HH_getConcurrentPack(hh2));
       linkInto(s, hh1, hh2);
 
       *cursor = hh1;
@@ -325,7 +325,7 @@ void HM_HH_merge(
   Trace2(EVENT_MERGED_HEAP, (EventInt)parentHH, (EventInt)childHH);
 
   // free stack of joining heap
-  CC_freeStack(HM_HH_getConcurrentPack(childHH));
+  CC_freeStack(s, HM_HH_getConcurrentPack(childHH));
 
   /* Merge levels. */
   parentThread->hierarchicalHeap = HM_HH_zip(s, parentHH, childHH);
@@ -382,7 +382,7 @@ void HM_HH_promoteChunks(
       /* shortcut.  */
       thread->hierarchicalHeap = parent;
       /* don't need the snapshot for this heap now. */
-      CC_freeStack(HM_HH_getConcurrentPack(hh));
+      CC_freeStack(s, HM_HH_getConcurrentPack(hh));
       linkInto(s, parent, hh);
       hh = parent;
     }
@@ -739,7 +739,7 @@ void mergeCompletedCCs(GC_state s, HM_HierarchicalHeap hh) {
         HM_HH_getConcurrentPack(completed)->bytesSurvivedLastCollection;
       HM_appendChunkList(HM_HH_getChunkList(hh), HM_HH_getChunkList(completed));
       HM_appendChunkList(HM_HH_getRemSet(hh), HM_HH_getRemSet(completed));
-      CC_freeStack(HM_HH_getConcurrentPack(completed));
+      CC_freeStack(s, HM_HH_getConcurrentPack(completed));
       linkInto(s, hh, completed);
       completed = next;
     }
@@ -1005,7 +1005,7 @@ Bool HM_HH_registerCont(pointer kl, pointer kr, pointer k, pointer threadp) {
   assert(listContainsChunk(HM_HH_getChunkList(hh), HM_getChunkOf(snapstackp)));
 #endif
 
-  CC_clearStack(HM_HH_getConcurrentPack(hh));
+  CC_clearStack(s, HM_HH_getConcurrentPack(hh));
   assert(HM_HH_getConcurrentPack(hh)->ccstate == CC_UNREG);
   __atomic_store_n(&(HM_HH_getConcurrentPack(hh)->ccstate), CC_REG, __ATOMIC_SEQ_CST);
   // HM_HH_getConcurrentPack(hh)->ccstate = CC_REG;

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -115,7 +115,7 @@ uint32_t HM_HH_getDepth(HM_HierarchicalHeap hh);
 bool HM_HH_isLevelHead(HM_HierarchicalHeap hh);
 
 bool HM_HH_isCCollecting(HM_HierarchicalHeap hh);
-void HM_HH_addRootForCollector(HM_HierarchicalHeap hh, pointer p);
+void HM_HH_addRootForCollector(GC_state s, HM_HierarchicalHeap hh, pointer p);
 
 void HM_HH_merge(GC_state s, GC_thread parent, GC_thread child);
 void HM_HH_promoteChunks(GC_state s, GC_thread thread);


### PR DESCRIPTION
Replaces the simple lock-based forgotten set (for snapshots) with a low-contention bag data structure. Also optimizes the communication between CC and write-barrier, to prevent unnecessary additions to the forgotten set. Specifically, CC now informs the write-barrier of its marking -> unmarking transition by "closing" the forgotten set, prevent further additions. The efficiency of this relies on the write-barrier only adding *unmarked* objects to the forgotten set, guaranteeing that the rate of additions decreases during the CC-marking phase. Eventually, after all live objects have been marked, there will be no further additions.