### PR TITLE
Switch to work list loop for CC

### DIFF
--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -49,6 +49,7 @@ extern C_Pthread_Key_t gcstate_key;
 #include "gc/block-allocator.c"
 #include "gc/call-stack.c"
 #include "gc/chunk.c"
+#include "gc/cc-work-list.c"
 #include "gc/concurrent-collection.c"
 #include "gc/concurrent-stack.c"
 #include "gc/controls.c"

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -1,0 +1,99 @@
+#include "cc-work-list.h"
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+
+void CC_workList_init(
+  __attribute__((unused)) GC_state s,
+  CC_workList w)
+{
+  HM_chunkList c = &(w->storage);
+  HM_initChunkList(c);
+  // arbitrary, just need an initial chunk
+  w->currentChunk = HM_allocateChunk(c, sizeof(objptr));
+}
+
+
+void CC_workList_push(
+  __attribute__((unused)) GC_state s,
+  CC_workList w,
+  objptr op)
+{
+  HM_chunkList list = &(w->storage);
+  HM_chunk chunk = w->currentChunk;
+  size_t opsz = sizeof(objptr);
+
+  if (HM_getChunkSizePastFrontier(chunk) < opsz) {
+    if (chunk->nextChunk != NULL) {
+      chunk = chunk->nextChunk; // this will be an empty chunk
+    } else {
+      chunk = HM_allocateChunk(list, opsz);
+    }
+    w->currentChunk = chunk;
+  }
+
+  assert(NULL != chunk);
+  assert(HM_getChunkSizePastFrontier(chunk) >= opsz);
+  assert(chunk == w->currentChunk);
+
+  pointer frontier = HM_getChunkFrontier(chunk);
+  HM_updateChunkFrontierInList(
+    list,
+    chunk,
+    frontier + opsz);
+
+  *((objptr*)frontier) = op;
+
+  return;
+}
+
+
+objptr CC_workList_pop(
+  GC_state s,
+  CC_workList w)
+{
+  HM_chunkList list = &(w->storage);
+  HM_chunk chunk = w->currentChunk;
+
+  if (HM_getChunkFrontier(chunk) <= HM_getChunkStart(chunk)) {
+    // chunk is empty; try to move backwards
+
+    HM_chunk prevChunk = chunk->prevChunk;
+    if (prevChunk == NULL) {
+      // whole worklist is empty
+      return BOGUS_OBJPTR;
+    }
+
+    /** Otherwise, there is a chunk before us. It's now safe (for cost
+      * amortization) to delete the chunk after us, if there is one.
+      */
+    if (NULL != chunk->nextChunk) {
+      HM_chunk nextChunk = chunk->nextChunk;
+      HM_unlinkChunk(list, nextChunk);
+      HM_freeChunk(s, nextChunk);
+    }
+
+    assert(NULL == chunk->nextChunk);
+    assert(prevChunk == chunk->prevChunk);
+
+    chunk = prevChunk;
+    w->currentChunk = chunk;
+  }
+
+  assert(w->currentChunk == chunk);
+  assert(HM_getChunkFrontier(chunk) >= HM_getChunkStart(chunk) + sizeof(objptr));
+
+  pointer frontier = HM_getChunkFrontier(chunk);
+  pointer newFrontier = frontier - sizeof(objptr);
+
+  HM_updateChunkFrontierInList(
+    list,
+    chunk,
+    newFrontier);
+
+  objptr result = *((objptr*)newFrontier);
+
+  return result;
+}
+
+#endif /* MLTON_GC_INTERNAL_FUNCS */

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -14,6 +14,26 @@ void CC_workList_init(
 }
 
 
+bool CC_workList_isEmpty(
+  __attribute__((unused)) GC_state s,
+  CC_workList w)
+{
+  HM_chunkList list = &(w->storage);
+  HM_chunk curr = w->currentChunk;
+
+  return
+    (list->firstChunk == curr)
+    &&
+    ((list->lastChunk == curr) || (list->lastChunk == curr->nextChunk))
+    &&
+    (HM_getChunkFrontier(curr) == HM_getChunkStart(curr))
+    &&
+    ( curr->nextChunk == NULL
+      || HM_getChunkFrontier(curr->nextChunk) == HM_getChunkStart(curr->nextChunk)
+    );
+}
+
+
 void CC_workList_push(
   __attribute__((unused)) GC_state s,
   CC_workList w,

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -17,6 +17,7 @@ typedef struct CC_workList * CC_workList;
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
+bool CC_workList_isEmpty(GC_state s, CC_workList w);
 void CC_workList_init(GC_state s, CC_workList w);
 void CC_workList_push(GC_state s, CC_workList w, objptr op);
 

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -1,0 +1,28 @@
+#ifndef CC_WORK_LIST_H
+#define CC_WORK_LIST_H
+
+#if (defined (MLTON_GC_INTERNAL_TYPES))
+
+typedef struct CC_workList {
+  struct HM_chunkList storage;
+  HM_chunk currentChunk;
+} * CC_workList;
+
+#else
+
+struct CC_workList;
+typedef struct CC_workList * CC_workList;
+
+#endif /* MLTON_GC_INTERNAL_TYPES */
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+void CC_workList_init(GC_state s, CC_workList w);
+void CC_workList_push(GC_state s, CC_workList w, objptr op);
+
+// returns BOGUS_OBJPTR if empty
+objptr CC_workList_pop(GC_state s, CC_workList w);
+
+#endif /* MLTON_GC_INTERNAL_FUNCS */
+
+#endif /* CC_WORK_LIST_H */

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -581,15 +581,21 @@ void HM_appendChunkList(HM_chunkList list1, HM_chunkList list2) {
 void HM_updateChunkFrontierInList(
   HM_chunkList list,
   HM_chunk chunk,
-  pointer frontier)
+  pointer newFrontier)
 {
+  assert(HM_getChunkStart(chunk) <= newFrontier);
+  assert(newFrontier <= chunk->limit);
+
   pointer oldFrontier = chunk->frontier;
-  assert(oldFrontier <= frontier && frontier <= chunk->limit);
+  chunk->frontier = newFrontier;
 
-  chunk->frontier = frontier;
+  if (NULL == list)
+    return;
 
-  if (NULL != list) {
-    list->usedSize += (size_t)frontier - (size_t)oldFrontier;
+  if (oldFrontier <= newFrontier) {
+    list->usedSize += (size_t)newFrontier - (size_t)oldFrontier;
+  } else {
+    list->usedSize -= (size_t)oldFrontier - (size_t)newFrontier;
   }
 }
 

--- a/runtime/gc/concurrent-collection.h
+++ b/runtime/gc/concurrent-collection.h
@@ -14,6 +14,7 @@
 #include "hierarchical-heap.h"
 #include "objptr.h"
 #include "deferred-promote.h"
+#include "cc-work-list.h"
 // #include "logger.h"
 
 
@@ -21,6 +22,7 @@
 
 // Struct to pass around args. repList is the new chunklist.
 typedef struct ConcurrentCollectArgs {
+  struct CC_workList worklist;
 	HM_chunkList origList;
 	HM_chunkList repList;
 	void* toHead;

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -193,7 +193,17 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
   uint32_t potentialLocalScope = UNPACK_IDX(topval);
   uint32_t originalLocalScope = pollCurrentLocalScope(s);
 
-  assert(thread->currentDepth == originalLocalScope);
+  if (thread->currentDepth != originalLocalScope) {
+    LOG(LM_HH_COLLECTION, LL_DEBUG,
+      "Skipping collection:\n"
+      "  currentDepth %u\n"
+      "  originalLocalScope %u\n"
+      "  potentialLocalScope %u\n",
+      thread->currentDepth,
+      originalLocalScope,
+      potentialLocalScope);
+    return;
+  }
 
   /** Compute the min depth for local collection. We claim as many levels
     * as we can without interfering with CC, but only so far as desired.

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -995,7 +995,7 @@ Bool HM_HH_registerCont(pointer kl, pointer kr, pointer k, pointer threadp) {
     size_t lastSurvived = heap->concurrentPack.bytesSurvivedLastCollection;
     size_t freshAlloc = heap->concurrentPack.bytesAllocatedSinceLastCollection;
     size_t size = HM_getChunkListSize(HM_HH_getChunkList(heap));
-    LOG(LM_CC_COLLECTION, LL_INFO,
+    LOG(LM_CC_COLLECTION, LL_DEBUG,
       "skipping at depth %u. last-survived: %zu new-alloc: %zu size: %zu",
       depth,
       lastSurvived,


### PR DESCRIPTION
The previous CC implementation traced the memory graph via a simple recursive loop. This works fine for well-parallelized benchmarks, where it's essential to avoid deep data structures to ensure good span. But of course, it's not difficult to cook up an example to blow up the C stack during CC and lead to a crash.

This patch fixes the issue with an explicit work list, where work is enqueued onto the list, and we loop over the list to trace the memory graph. The work-list data structure is a simple list-of-chunks with LIFO ordering. We amortize additions and deletions by allocating and freeing chunks on demand.

After some initial testing, it doesn't look like this affects the performance of CC too much (both time and space), which is expected. It just removes the bad worst-case behavior.