### PR TITLE
Better space performance for CC work list

### DIFF
--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -10,7 +10,7 @@ void CC_workList_init(
   HM_chunkList c = &(w->storage);
   HM_initChunkList(c);
   // arbitrary, just need an initial chunk
-  w->currentChunk = HM_allocateChunk(c, sizeof(objptr));
+  w->currentChunk = HM_allocateChunk(c, sizeof(struct CC_workList_elem));
 }
 
 
@@ -34,86 +34,211 @@ bool CC_workList_isEmpty(
 }
 
 
+bool mightHaveObjptrs(GC_state s, objptr op) {
+  GC_header header;
+  uint16_t bytesNonObjptrs;
+  uint16_t numObjptrs;
+  GC_objectTypeTag tag;
+  header = getHeader(objptrToPointer(op, NULL));
+  splitHeader(s, header, &tag, NULL, &bytesNonObjptrs, &numObjptrs);
+
+  return (STACK_TAG == tag) || (numObjptrs > 0);
+}
+
+
 void CC_workList_push(
-  __attribute__((unused)) GC_state s,
+  GC_state s,
   CC_workList w,
   objptr op)
 {
+  if (!mightHaveObjptrs(s, op))
+    return;
+
   HM_chunkList list = &(w->storage);
   HM_chunk chunk = w->currentChunk;
-  size_t opsz = sizeof(objptr);
+  size_t elemSize = sizeof(struct CC_workList_elem);
 
-  if (HM_getChunkSizePastFrontier(chunk) < opsz) {
+  if (HM_getChunkSizePastFrontier(chunk) < elemSize) {
     if (chunk->nextChunk != NULL) {
       chunk = chunk->nextChunk; // this will be an empty chunk
     } else {
-      chunk = HM_allocateChunk(list, opsz);
+      chunk = HM_allocateChunk(list, elemSize);
     }
     w->currentChunk = chunk;
   }
 
   assert(NULL != chunk);
-  assert(HM_getChunkSizePastFrontier(chunk) >= opsz);
+  assert(HM_getChunkSizePastFrontier(chunk) >= elemSize);
   assert(chunk == w->currentChunk);
 
   pointer frontier = HM_getChunkFrontier(chunk);
   HM_updateChunkFrontierInList(
     list,
     chunk,
-    frontier + opsz);
+    frontier + elemSize);
 
-  *((objptr*)frontier) = op;
+  CC_workList_elem elem = (CC_workList_elem)frontier;
+  elem->op = op;
+  elem->pos = objptrToPointer(op, NULL);
 
   return;
 }
 
 
-objptr CC_workList_pop(
+struct advanceOneFieldResult {
+  objptr* field;
+  bool objectDone;
+};
+
+void advanceOneField(
+  GC_state s,
+  CC_workList_elem elem,
+  struct advanceOneFieldResult * result)
+{
+  pointer p = objptrToPointer(elem->op, NULL);
+  pointer pos = elem->pos;
+
+  // inspect the object
+  GC_header header;
+  uint16_t bytesNonObjptrs;
+  uint16_t numObjptrs;
+  GC_objectTypeTag tag;
+  header = getHeader(p);
+  splitHeader(s, header, &tag, NULL, &bytesNonObjptrs, &numObjptrs);
+
+  // ======================== NORMAL OBJECTS ========================
+
+  if (NORMAL_TAG == tag) {
+    pointer end = p + bytesNonObjptrs + (numObjptrs * OBJPTR_SIZE);
+    pointer fieldsStart = p + bytesNonObjptrs;
+
+    if (pos < fieldsStart) pos = fieldsStart;
+
+    if (pos < end) {
+      result->field = (objptr*)pos;
+      pos = pos + OBJPTR_SIZE;
+    } else {
+      result->field = NULL;
+    }
+
+    elem->pos = pos;
+    result->objectDone = (pos >= end);
+    return;
+  }
+
+  // ======================== SEQUENCE OBJECTS ========================
+
+  if (SEQUENCE_TAG == tag) {
+
+    if (0 == numObjptrs) {
+      /* No objptrs to process. */
+      result->field = NULL;
+      result->objectDone = TRUE;
+      return;
+    }
+
+    GC_sequenceLength numCells = getSequenceLength(p);
+    size_t bytesPerCell = bytesNonObjptrs + (numObjptrs * OBJPTR_SIZE);
+    size_t dataBytes = numCells * bytesPerCell;
+    pointer last = p + dataBytes;
+
+    // size_t posOffset = (size_t)(pos-p);
+    // pointer cellStart = p + alignDown(posOffset, bytesPerCell);
+    pointer cellStart = pos - ((size_t)pos % bytesPerCell);
+
+    pointer cellEnd = cellStart + bytesNonObjptrs + (numObjptrs * OBJPTR_SIZE);
+    pointer fieldsStart = cellStart + bytesNonObjptrs;
+
+    if (pos < fieldsStart) pos = fieldsStart;
+
+    if (pos < cellEnd) {
+      result->field = (objptr*)pos;
+      pos = pos + OBJPTR_SIZE;
+    } else {
+      result->field = NULL;
+    }
+
+    elem->pos = pos;
+    result->objectDone = (pos >= last);
+
+    return;
+  }
+
+  // ======================== STACK OBJECTS ========================
+
+  if (STACK_TAG == tag) {
+    DIE("advanceOneField: stack objects not implemented yet");
+    return;
+  }
+
+  // ======================== OTHERWISE... ========================
+
+  DIE("advanceOneField: cannot handle tag %u", tag);
+  return;
+}
+
+
+objptr* CC_workList_pop(
   GC_state s,
   CC_workList w)
 {
   HM_chunkList list = &(w->storage);
-  HM_chunk chunk = w->currentChunk;
 
-  if (HM_getChunkFrontier(chunk) <= HM_getChunkStart(chunk)) {
-    // chunk is empty; try to move backwards
+  /** It's possible to not succeed in finding a field in the most recent
+    * object (if the object doesn't have remaining objptrs). So, if we fail,
+    * try again. Eventually this will either return NULL because the worklist
+    * is empty, or it will return a field pointer.
+    */
+  while (TRUE) {
+    HM_chunk chunk = w->currentChunk;
 
-    HM_chunk prevChunk = chunk->prevChunk;
-    if (prevChunk == NULL) {
-      // whole worklist is empty
-      return BOGUS_OBJPTR;
+    if (HM_getChunkFrontier(chunk) <= HM_getChunkStart(chunk)) {
+      // chunk is empty; try to move backwards
+
+      HM_chunk prevChunk = chunk->prevChunk;
+      if (prevChunk == NULL) {
+        // whole worklist is empty
+        return NULL;
+      }
+
+      /** Otherwise, there is a chunk before us. It's now safe (for cost
+        * amortization) to delete the chunk after us, if there is one.
+        */
+      if (NULL != chunk->nextChunk) {
+        HM_chunk nextChunk = chunk->nextChunk;
+        HM_unlinkChunk(list, nextChunk);
+        HM_freeChunk(s, nextChunk);
+      }
+
+      assert(NULL == chunk->nextChunk);
+      assert(prevChunk == chunk->prevChunk);
+
+      chunk = prevChunk;
+      w->currentChunk = chunk;
     }
 
-    /** Otherwise, there is a chunk before us. It's now safe (for cost
-      * amortization) to delete the chunk after us, if there is one.
-      */
-    if (NULL != chunk->nextChunk) {
-      HM_chunk nextChunk = chunk->nextChunk;
-      HM_unlinkChunk(list, nextChunk);
-      HM_freeChunk(s, nextChunk);
+    assert(w->currentChunk == chunk);
+    assert(HM_getChunkFrontier(chunk) >= HM_getChunkStart(chunk) + sizeof(struct CC_workList_elem));
+
+    pointer frontier = HM_getChunkFrontier(chunk);
+    pointer elemPtr = frontier - sizeof(struct CC_workList_elem);
+    CC_workList_elem elem = (CC_workList_elem)elemPtr;
+
+    struct advanceOneFieldResult r;
+    advanceOneField(s, elem, &r);
+
+    if (r.objectDone) {
+      pointer newFrontier = elemPtr;
+      HM_updateChunkFrontierInList(
+        list,
+        chunk,
+        newFrontier);
     }
 
-    assert(NULL == chunk->nextChunk);
-    assert(prevChunk == chunk->prevChunk);
-
-    chunk = prevChunk;
-    w->currentChunk = chunk;
+    // We should only return NULL if the work list is empty.
+    if (NULL != r.field)
+      return r.field;
   }
-
-  assert(w->currentChunk == chunk);
-  assert(HM_getChunkFrontier(chunk) >= HM_getChunkStart(chunk) + sizeof(objptr));
-
-  pointer frontier = HM_getChunkFrontier(chunk);
-  pointer newFrontier = frontier - sizeof(objptr);
-
-  HM_updateChunkFrontierInList(
-    list,
-    chunk,
-    newFrontier);
-
-  objptr result = *((objptr*)newFrontier);
-
-  return result;
 }
 
 #endif /* MLTON_GC_INTERNAL_FUNCS */

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -36,11 +36,10 @@ bool CC_workList_isEmpty(
 
 bool mightHaveObjptrs(GC_state s, objptr op) {
   GC_header header;
-  uint16_t bytesNonObjptrs;
   uint16_t numObjptrs;
   GC_objectTypeTag tag;
   header = getHeader(objptrToPointer(op, NULL));
-  splitHeader(s, header, &tag, NULL, &bytesNonObjptrs, &numObjptrs);
+  splitHeader(s, header, &tag, NULL, NULL, &numObjptrs);
 
   return (STACK_TAG == tag) || (numObjptrs > 0);
 }
@@ -142,9 +141,9 @@ void advanceOneField(
     size_t dataBytes = numCells * bytesPerCell;
     pointer last = p + dataBytes;
 
-    // size_t posOffset = (size_t)(pos-p);
+    size_t posOffset = (size_t)(pos-p);
     // pointer cellStart = p + alignDown(posOffset, bytesPerCell);
-    pointer cellStart = pos - ((size_t)pos % bytesPerCell);
+    pointer cellStart = pos - ((size_t)posOffset % bytesPerCell);
 
     pointer cellEnd = cellStart + bytesNonObjptrs + (numObjptrs * OBJPTR_SIZE);
     pointer fieldsStart = cellStart + bytesNonObjptrs;

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -8,10 +8,27 @@ typedef struct CC_workList {
   HM_chunk currentChunk;
 } * CC_workList;
 
+typedef struct CC_workList_elem {
+  objptr op;    // object front
+  pointer pos;  // where inside object did we leave off?
+} * CC_workList_elem;
+
+// struct CC_workList_range {
+//   objptr op;
+//   pointer start;
+//   pointer stop;
+// } * CC_workList_range;
+
 #else
 
 struct CC_workList;
 typedef struct CC_workList * CC_workList;
+
+struct CC_workList_elem;
+typedef struct CC_workList_elem * CC_workList_elem;
+
+struct CC_workList_range;
+typedef struct CC_workList_range * CC_workList_range;
 
 #endif /* MLTON_GC_INTERNAL_TYPES */
 
@@ -21,8 +38,11 @@ bool CC_workList_isEmpty(GC_state s, CC_workList w);
 void CC_workList_init(GC_state s, CC_workList w);
 void CC_workList_push(GC_state s, CC_workList w, objptr op);
 
-// returns BOGUS_OBJPTR if empty
-objptr CC_workList_pop(GC_state s, CC_workList w);
+/** Returns a single field of an object that still needs to be traced.
+  * So, note that a single push can result in many pops.
+  *
+  * Returns NULL if work list is empty */
+objptr* CC_workList_pop(GC_state s, CC_workList w);
 
 #endif /* MLTON_GC_INTERNAL_FUNCS */
 

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -18,6 +18,10 @@ typedef struct CC_workList_elem {
       size_t cellIdx;
       uint16_t objptrIdx;
     } sequence;
+    struct stack {
+      pointer topCursor;
+      unsigned int frameOffsetsIdx;
+    } stack;
   } data;
 } * CC_workList_elem;
 

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -10,14 +10,16 @@ typedef struct CC_workList {
 
 typedef struct CC_workList_elem {
   objptr op;    // object front
-  pointer pos;  // where inside object did we leave off?
+  union data {
+    struct normal {
+      uint16_t objptrIdx;
+    } normal;
+    struct sequence {
+      size_t cellIdx;
+      uint16_t objptrIdx;
+    } sequence;
+  } data;
 } * CC_workList_elem;
-
-// struct CC_workList_range {
-//   objptr op;
-//   pointer start;
-//   pointer stop;
-// } * CC_workList_range;
 
 #else
 

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -965,7 +965,7 @@ size_t CC_collectWithRoots(
   forceForward(s, &(cp->snapLeft), &lists);
   forceForward(s, &(cp->snapRight), &lists);
   forceForward(s, &(cp->snapTemp), &lists);
-  forceForward(s, &(s->wsQueue), &lists);
+  // forceForward(s, &(s->wsQueue), &lists);
   forceForward(s, &(cp->stack), &lists);
 
   markLoop(s, &lists);
@@ -1024,7 +1024,7 @@ size_t CC_collectWithRoots(
   forceUnmark(s, &(cp->snapLeft), &lists);
   forceUnmark(s, &(cp->snapRight), &lists);
   forceUnmark(s, &(cp->snapTemp), &lists);
-  forceUnmark(s, &(s->wsQueue), &lists);
+  // forceUnmark(s, &(s->wsQueue), &lists);
   forceUnmark(s, &(cp->stack), &lists);
 
   unmarkLoop(s, &lists);

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -532,22 +532,8 @@ void forceForward(GC_state s, objptr *opp, void* rawArgs) {
     args->bytesSaved += sizeofObject(s, p);
   }
 
-  // struct GC_foreachObjptrClosure forwardPtrClosure =
-  // {.fun = forwardPtrChunk, .env = rawArgs};
-  // foreachObjptrInObject(s, p, &trueObjptrPredicateClosure,
-  //         &forwardPtrClosure, FALSE);
-
-  // TODO: update cc-worklist to allow for stacks...
-  GC_objectTypeTag tag;
-  splitHeader(s, getHeader(p), &tag, NULL, NULL, NULL);
-  if (STACK_TAG == tag) {
-    struct GC_foreachObjptrClosure markAddClosure =
-      {.fun = tryMarkAndMarkLoop, .env = rawArgs};
-    foreachObjptrInObject(s, p, &trueObjptrPredicateClosure, &markAddClosure, FALSE);
-  } else {
-    CC_workList_push(s, &(args->worklist), op);
-    markLoop(s, rawArgs);
-  }
+  CC_workList_push(s, &(args->worklist), op);
+  markLoop(s, rawArgs);
 }
 
 void forceUnmark (GC_state s, objptr* opp, void* rawArgs) {
@@ -563,18 +549,8 @@ void forceUnmark (GC_state s, objptr* opp, void* rawArgs) {
     assert(!CC_isPointerMarked(p));
   }
 
-  // TODO: update cc-worklist to allow for stacks...
-  GC_objectTypeTag tag;
-  splitHeader(s, getHeader(p), &tag, NULL, NULL, NULL);
-  if (STACK_TAG == tag) {
-    struct GC_foreachObjptrClosure unmarkClosure =
-      {.fun = tryUnmarkAndUnmarkLoop, .env = rawArgs};
-    foreachObjptrInObject(s, p, &trueObjptrPredicateClosure,
-            &unmarkClosure, FALSE);
-  } else {
-    CC_workList_push(s, &(args->worklist), op);
-    unmarkLoop(s, rawArgs);
-  }
+  CC_workList_push(s, &(args->worklist), op);
+  unmarkLoop(s, rawArgs);
 }
 
 void ensureCallSanity(

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -358,6 +358,8 @@ void markLoop(GC_state s, ConcurrentCollectArgs* args) {
     callIfIsObjptr(s, &markAddClosure, current);
     current = CC_workList_pop(s, worklist);
   }
+
+  assert(CC_workList_isEmpty(s, worklist));
 }
 
 void unmarkLoop(GC_state s, ConcurrentCollectArgs* args) {
@@ -371,6 +373,8 @@ void unmarkLoop(GC_state s, ConcurrentCollectArgs* args) {
     callIfIsObjptr(s, &unmarkAddClosure, current);
     current = CC_workList_pop(s, worklist);
   }
+
+  assert(CC_workList_isEmpty(s, worklist));
 }
 
 #if 0

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -353,15 +353,9 @@ void markLoop(GC_state s, ConcurrentCollectArgs* args) {
 
   CC_workList worklist = &(args->worklist);
 
-  objptr current = CC_workList_pop(s, worklist);
-  while (current != BOGUS_OBJPTR) {
-    foreachObjptrInObject(
-      s,
-      objptrToPointer(current, NULL),
-      &trueObjptrPredicateClosure,
-      &markAddClosure,
-      FALSE);
-
+  objptr* current = CC_workList_pop(s, worklist);
+  while (NULL != current) {
+    callIfIsObjptr(s, &markAddClosure, current);
     current = CC_workList_pop(s, worklist);
   }
 }
@@ -372,15 +366,9 @@ void unmarkLoop(GC_state s, ConcurrentCollectArgs* args) {
 
   CC_workList worklist = &(args->worklist);
 
-  objptr current = CC_workList_pop(s, worklist);
-  while (current != BOGUS_OBJPTR) {
-    foreachObjptrInObject(
-      s,
-      objptrToPointer(current, NULL),
-      &trueObjptrPredicateClosure,
-      &unmarkAddClosure,
-      FALSE);
-
+  objptr* current = CC_workList_pop(s, worklist);
+  while (NULL != current) {
+    callIfIsObjptr(s, &unmarkAddClosure, current);
     current = CC_workList_pop(s, worklist);
   }
 }


### PR DESCRIPTION
This implements both suggestions in #148:
  * Each work list entry now contains an offset, indicating how much more of the given object needs to be traced. This allows for pushing large objects onto the work-stack in constant time and space.
  * CC now performs a full DFS mark/unmark loop for each individual item pushed onto the stack. This means that the order in which objects are traced, as well as the amount of space required for CC, should be identical to 6c1af00c2f3bc970ba46b0a4f4b90e840308b550 and before.

In terms of benchmarks, `triangle-count` was previously using 30% more space due to the CC work list (as measured in discussion [here](https://github.com/MPLLang/mpl/pull/147#issuecomment-1061285273)), but now appears to be using the same amount of space as it used to. I am still measuring that `dedup-strings` consumes more space than it did under 6c1af00c2f3bc970ba46b0a4f4b90e840308b550, but only on large repeat counts. This suggests the difference is due to CC timing issues, rather than the space consumption of CC itself. The space consumption of all other benchmarks I've tried doesn't seem to be affected much.