### PR TITLE
fix #149 by passing the read value through

### DIFF
--- a/runtime/gc/foreach.c
+++ b/runtime/gc/foreach.c
@@ -8,12 +8,13 @@
  */
 
 void callIfIsObjptr (GC_state s, GC_foreachObjptrClosure f, objptr *opp) {
-  if (isObjptr (*opp)) {
+  objptr op = *opp;
+  if (isObjptr(op)) {
     LOG(LM_FOREACH, LL_DEBUG,
         "Calling for opp "FMTPTR" op "FMTOBJPTR,
         ((uintptr_t)(opp)),
         *opp);
-    f->fun (s, opp, f->env);
+    f->fun(s, opp, op, f->env);
   }
 }
 
@@ -279,7 +280,7 @@ pointer foreachObjptrInRange (GC_state s, pointer front, pointer *back,
 
   assert (isFrontierAligned (s, front));
   if (DEBUG_DETAILED)
-    fprintf (stderr, 
+    fprintf (stderr,
              "foreachObjptrInRange  front = "FMTPTR"  *back = "FMTPTR"\n",
              (uintptr_t)front, (uintptr_t)(*back));
   b = *back;
@@ -288,7 +289,7 @@ pointer foreachObjptrInRange (GC_state s, pointer front, pointer *back,
     while (front < b) {
       assert (isAligned ((size_t)front, GC_MODEL_MINALIGN));
       if (DEBUG_DETAILED)
-        fprintf (stderr, 
+        fprintf (stderr,
                  "  front = "FMTPTR"  *back = "FMTPTR"\n",
                  (uintptr_t)front, (uintptr_t)(*back));
       pointer p = advanceToObjectData (s, front);

--- a/runtime/gc/foreach.h
+++ b/runtime/gc/foreach.h
@@ -9,7 +9,7 @@
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-typedef void (*GC_foreachObjptrFun) (GC_state s, objptr *opp, void *env);
+typedef void (*GC_foreachObjptrFun) (GC_state s, objptr *opp, objptr op, void *env);
 
 typedef struct GC_foreachObjptrClosure {
   GC_foreachObjptrFun fun;
@@ -33,7 +33,7 @@ void printObjectsInRange(GC_state s, pointer front, pointer back);
  */
 static inline void foreachGlobalObjptr (GC_state s, GC_foreachObjptrClosure f);
 /* foreachObjptrInObject (s, p, skipWeaks, f)
- * 
+ *
  * Applies f to each object pointer in the object pointed to by p.
  * Returns pointer to the end of object, i.e. just past object.
  *

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -485,7 +485,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope) {
     "Trying to forward current thread %p",
     (void*)s->currentThread);
   oldObjectCopied = forwardHHObjptrArgs.objectsCopied;
-  forwardHHObjptr(s, &(s->currentThread), &forwardHHObjptrArgs);
+  forwardHHObjptr(s, &(s->currentThread), s->currentThread, &forwardHHObjptrArgs);
   LOG(LM_HH_COLLECTION, LL_DEBUG,
       (1 == (forwardHHObjptrArgs.objectsCopied - oldObjectCopied)) ?
       "Copied thread from GC_state" : "Did not copy thread from GC_state");
@@ -1172,16 +1172,18 @@ void forwardObjptrsOfRemembered(GC_state s, HM_remembered remElem, void* rawArgs
     FALSE
   );
 
-  forwardHHObjptr(s, &(remElem->from), rawArgs);
+  forwardHHObjptr(s, &(remElem->from), remElem->from, rawArgs);
 }
 
 /* ========================================================================= */
 
-void forwardHHObjptr (GC_state s,
-                      objptr* opp,
-                      void* rawArgs) {
+void forwardHHObjptr(
+  GC_state s,
+  objptr* opp,
+  objptr op,
+  void* rawArgs)
+{
   struct ForwardHHObjptrArgs* args = ((struct ForwardHHObjptrArgs*)(rawArgs));
-  objptr op = *opp;
   pointer p = objptrToPointer (op, NULL);
 
   assert(args->toDepth == HM_HH_INVALID_DEPTH);

--- a/runtime/gc/hierarchical-heap-collection.h
+++ b/runtime/gc/hierarchical-heap-collection.h
@@ -73,7 +73,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope);
  * @param opp The objptr to forward
  * @param args The struct ForwardHHObjptrArgs* for this call, cast as a void*
  */
-void forwardHHObjptr (GC_state s, objptr* opp, void* rawArgs);
+void forwardHHObjptr(GC_state s, objptr* opp, objptr op, void* rawArgs);
 
 /* check if `op` is in args->toSpace[depth(op)] */
 bool isObjptrInToSpace(objptr op, struct ForwardHHObjptrArgs *args);


### PR DESCRIPTION
A simple fix. Just changed the `GC_foreachObjptrFun` interface, and all functions that are passed as argument to things like `foreachObjptrInObject`.

These functions used to take three arguments: `(GC_state s, objptr *opp, void *env)`. Now they take four: `(GC_state s, objptr *opp, objptr op, void *env)`. The idea is that `op = *opp`, where in almost all cases, the function is called via `callIfIsObjptr` after it has checked `isObjptr(op)`. This fix ensures that `opp` is not dereferenced a second time unnecessarily.