### PR TITLE
bugfix: `copySuspect` and `clear_suspect` must adhere to `GC_foreachObjptrFun` interface

### DIFF
--- a/runtime/gc/entanglement-suspects.c
+++ b/runtime/gc/entanglement-suspects.c
@@ -22,13 +22,12 @@ static inline bool is_suspect(objptr op)
 
 void clear_suspect(
     __attribute__((unused)) GC_state s,
-    objptr *opp,
+    __attribute__((unused)) objptr *opp,
+    objptr op,
     __attribute__((unused)) void *rawArgs)
 {
-
-  objptr op = *opp;
   pointer p = objptrToPointer(op, NULL);
-  assert(isObjptr(op) && is_suspect(p));
+  assert(isObjptr(op) && is_suspect(op));
   __sync_fetch_and_and(getHeaderp(p), ~(SUSPECT_MASK));
 }
 

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -44,7 +44,7 @@ void tryUnpinOrKeepPinned(
   HM_remembered remElem,
   void* rawArgs);
 
-void copySuspect(GC_state s, objptr *opp, void *rawArghh);
+void copySuspect(GC_state s, objptr *opp, objptr op, void *rawArghh);
 
 void forwardObjptrsOfRemembered(
   GC_state s,
@@ -1055,9 +1055,13 @@ void unfreezeDisentangledDepthAfter(
 #endif
 
 /* ========================================================================= */
-void copySuspect(GC_state s, objptr *opp, void *rawArghh)  {
+void copySuspect(
+  GC_state s,
+  __attribute__((unused)) objptr *opp,
+  objptr op,
+  void *rawArghh)
+{
   struct ForwardHHObjptrArgs *args = (struct ForwardHHObjptrArgs *)rawArghh;
-  objptr op = *opp;
   assert(isObjptr(op));
   pointer p = objptrToPointer(op, NULL);
   objptr new_ptr = op;


### PR DESCRIPTION
The bug was introduced in #154, as the changes in #151 weren't carried through to the entanglement suspects patch. This fixes that.