### PR TITLE
`ChunkSet` data-structure, implements a hash set of chunk-ids

### DIFF
--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -49,6 +49,7 @@ extern C_Pthread_Key_t gcstate_key;
 #include "gc/block-allocator.c"
 #include "gc/call-stack.c"
 #include "gc/chunk.c"
+#include "gc/chunk-set.c"
 #include "gc/cc-work-list.c"
 #include "gc/concurrent-collection.c"
 #include "gc/concurrent-stack.c"

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -43,6 +43,7 @@ typedef GC_state GCState_t;
 #include "gc/foreach.h"
 #include "gc/stack.h"
 #include "gc/chunk.h"
+#include "gc/chunk-set.h"
 #include "gc/fixed-size-allocator.h"
 #include "gc/thread.h"
 #include "gc/weak.h"

--- a/runtime/gc/chunk-set.c
+++ b/runtime/gc/chunk-set.c
@@ -1,0 +1,166 @@
+/* Copyright (C) 2022 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#include "chunk-set.h"
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+#define EMPTY_SLOT ((HM_chunk)0)
+#define TOMBSTONE  ((HM_chunk)1)
+
+// from numerical recipes
+static inline uint64_t hash64(uint64_t u) {
+  uint64_t v = u * 3935559000370003845ul + 2691343689449507681ul;
+  v ^= v >> 21;
+  v ^= v << 37;
+  v ^= v >> 4;
+  v *= 4768777513237032717ul;
+  v ^= v << 20;
+  v ^= v >> 41;
+  v ^= v << 5;
+  return v;
+}
+
+
+// a slightly cheaper, but possibly not as good version
+// based on splitmix64
+static inline uint64_t hash64_2(uint64_t x) {
+  x = (x ^ (x >> 30)) * (uint64_t)0xbf58476d1ce4e5b9;
+  x = (x ^ (x >> 27)) * (uint64_t)0x94d049bb133111eb;
+  x = x ^ (x >> 31);
+  return x;
+}
+
+
+static inline size_t ChunkSet_hashToIndex(HM_chunk chunkp, size_t capacity) {
+  uint64_t p = (uint64_t)(uintptr_t)chunkp;
+  return ((size_t)hash64_2(p)) % capacity;
+}
+
+
+void ChunkSet_init(GC_state s, ChunkSet set, size_t numBlocks) {
+  Blocks bs = allocateBlocks(s, numBlocks);
+  assert(bs->numBlocks >= numBlocks);
+
+  set->container = bs->container;
+  set->numBlocks = bs->numBlocks;
+  set->capacity = (bs->numBlocks * s->controls->blockSize) / sizeof(HM_chunk);
+  set->size = 0;
+  set->data = (HM_chunk*)(void*)bs;
+
+  for (size_t i = 0; i < set->capacity; i++) {
+    set->data[i] = EMPTY_SLOT;
+  }
+}
+
+
+void ChunkSet_free(GC_state s, ChunkSet set) {
+  SuperBlock container = set->container;
+  size_t numBlocks = set->numBlocks;
+  Blocks bs = (Blocks)(void*)set->data;
+  bs->container = container;
+  bs->numBlocks = numBlocks;
+  freeBlocks(s, bs, NULL);
+
+  set->container = NULL;
+  set->numBlocks = 0;
+  set->capacity = 0;
+  set->size = 0;
+  set->data = NULL;
+}
+
+
+void ChunkSet_resize(GC_state s, ChunkSet old) {
+  struct ChunkSet new_;
+  ChunkSet new = &new_;
+
+  ChunkSet_init(s, new, 2 * old->numBlocks);
+
+  for (size_t i = 0; i < old->capacity; i++) {
+    HM_chunk elem = old->data[i];
+    if ( (EMPTY_SLOT != elem) && (TOMBSTONE != elem) ) {
+      ChunkSet_insert(s, new, elem);
+    }
+  }
+
+  ChunkSet_free(s, old);
+
+  *old = *new;
+}
+
+
+bool ChunkSet_insert(GC_state s, ChunkSet set, HM_chunk chunkp) {
+  assert(EMPTY_SLOT != chunkp && TOMBSTONE != chunkp);
+
+  if ( ((double)set->size / (double)set->capacity) >= 0.75 ) {
+    ChunkSet_resize(s, set);
+  }
+  assert(set->size < set->capacity);
+
+  size_t i = ChunkSet_hashToIndex(chunkp, set->capacity);
+  while (TRUE) {
+    HM_chunk contents = set->data[i];
+    if (contents == EMPTY_SLOT || contents == TOMBSTONE) {
+      set->data[i] = chunkp;
+      set->size++;
+      return TRUE;
+    }
+
+    if (contents == chunkp) {
+      return FALSE;
+    }
+
+    i = (i+1 < set->capacity ? i+1 : 0);
+  }
+}
+
+bool ChunkSet_contains(
+  __attribute__((unused)) GC_state s,
+  ChunkSet set,
+  HM_chunk chunkp)
+{
+  assert(EMPTY_SLOT != chunkp && TOMBSTONE != chunkp);
+
+  size_t i = ChunkSet_hashToIndex(chunkp, set->capacity);
+  while (TRUE) {
+    HM_chunk contents = set->data[i];
+    if (contents == EMPTY_SLOT) {
+      return FALSE;
+    }
+
+    if (contents == chunkp) {
+      return TRUE;
+    }
+
+    i = (i+1 < set->capacity ? i+1 : 0);
+  }
+}
+
+bool ChunkSet_remove(
+  __attribute__((unused)) GC_state s,
+  ChunkSet set,
+  HM_chunk chunkp)
+{
+  assert(EMPTY_SLOT != chunkp && TOMBSTONE != chunkp);
+
+  size_t i = ChunkSet_hashToIndex(chunkp, set->capacity);
+  while (TRUE) {
+    HM_chunk contents = set->data[i];
+    if (contents == EMPTY_SLOT) {
+      return FALSE;
+    }
+
+    if (contents == chunkp) {
+      set->data[i] = TOMBSTONE;
+      set->size--;
+      return TRUE;
+    }
+
+    i = (i+1 < set->capacity ? i+1 : 0);
+  }
+}
+
+#endif

--- a/runtime/gc/chunk-set.h
+++ b/runtime/gc/chunk-set.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 2022 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#ifndef CHUNK_SET_H_
+#define CHUNK_SET_H_
+
+#include "block-allocator.h"
+
+#if (defined (MLTON_GC_INTERNAL_TYPES))
+// declare and define
+
+struct ChunkSet {
+  HM_chunk *data;
+  size_t size;
+  size_t capacity;
+
+  // These are needed to free the data
+  size_t numBlocks;
+  SuperBlock container;
+};
+
+typedef struct ChunkSet * ChunkSet;
+
+#else
+// just declare
+
+struct ChunkSet;
+typedef struct ChunkSet * ChunkSet;
+
+#endif /* defined (MLTON_GC_INTERNAL_TYPES) */
+
+
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+void ChunkSet_init(GC_state s, ChunkSet set, size_t numBlocks);
+void ChunkSet_free(GC_state s, ChunkSet set);
+
+bool ChunkSet_contains(GC_state s, ChunkSet set, HM_chunk chunk);
+
+// returns TRUE if success; FALSE if already contained
+bool ChunkSet_insert(GC_state s, ChunkSet set, HM_chunk chunk);
+
+// returns TRUE if success; FALSE if not present
+bool ChunkSet_remove(GC_state s, ChunkSet set, HM_chunk chunk);
+
+#endif /* defined (MLTON_GC_INTERNAL_FUNCS) */
+
+
+#endif /* CHUNK_SET_H_ */

--- a/runtime/gc/concurrent-collection.h
+++ b/runtime/gc/concurrent-collection.h
@@ -28,6 +28,12 @@ typedef struct ConcurrentCollectArgs {
 	void* toHead;
 	void* fromHead;
   size_t bytesSaved;
+
+#if ASSERT
+  struct ChunkSet fromSpaceChunks;
+  struct ChunkSet toSpaceChunks;
+#endif
+
 } ConcurrentCollectArgs;
 
 


### PR DESCRIPTION
Preliminary implementation, not optimized yet. Just a simple hash-set, with linear probing and tombstones for deletion. Allocation is backed by the block allocator, to avoid space+time overhead of `malloc`.

At the moment I'm using `ChunkSet` in assertions during CGC to check that the scope is being handled correctly (consider #137).

There may be other uses throughout the runtime system. Anywhere we are marking chunk descriptors for some reason, we could instead use a `ChunkSet` to avoid reserving space in the chunk descriptor. For example, we could eliminate the [`chunk->pinnedDuringCollection`](https://github.com/MPLLang/mpl/blob/b69ca194fc22ade32b571393f0433de77ab48ebb/runtime/gc/chunk.h#L67) flag by maintaining a set of pinned chunks in LGC. The secondary advantage, as illustrated by #137, is that it is helpful to avoid modifying chunk descriptors, because this can be problematic for concurrency, especially when chunks are freed to the block allocator.

I'm opening this pull request mainly just to not forget about this. Switching to using `ChunkSet`s more pervasively will require more thorough testing and optimization. It's not pressing, but it's something we should consider.