### PR TITLE
Enable entanglement detection by default (prepping for v0.3 release)

### DIFF
--- a/basis-library/schedulers/shh/Scheduler.sml
+++ b/basis-library/schedulers/shh/Scheduler.sml
@@ -568,6 +568,7 @@ struct
     if HH.getDepth originalThread = 0 then ()
     else die (fn _ => "scheduler bug: root depth <> 0")
   val _ = HH.setDepth (originalThread, 1)
+  val _ = HH.forceLeftHeap (myWorkerId (), originalThread)
 
   (* implicitly attaches worker child heaps *)
   val _ = MLton.Parallel.initializeProcessors ()

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,7 +2,7 @@ MPL=../build/bin/mpl
 FLAGS=-default-type int64 -default-type word64
 DBG_FLAGS=-debug true -debug-runtime true -keep g
 TRACE_FLAGS=-trace true -trace-runtime true
-DETECT_FLAGS=-detect-entanglement true
+NODETECT_FLAGS=-detect-entanglement false
 
 PROGRAMS= \
 	fib \
@@ -21,14 +21,14 @@ PROGRAMS= \
 
 TRACE_PROGRAMS := $(addsuffix .trace,$(PROGRAMS))
 DBG_PROGRAMS := $(addsuffix .dbg,$(PROGRAMS))
-DETECT_PROGRAMS := $(addsuffix .detect,$(PROGRAMS))
+NODETECT_PROGRAMS := $(addsuffix .nodetect,$(PROGRAMS))
 SYSMPL_PROGRAMS := $(addsuffix .sysmpl,$(PROGRAMS))
 
 all: $(PROGRAMS)
 
 all-dbg: $(DBG_PROGRAMS)
 
-all-detect: $(DETECT_PROGRAMS)
+all-nodetect: $(DETECT_PROGRAMS)
 
 all-sysmpl: $(SYSMPL_PROGRAMS)
 
@@ -47,10 +47,10 @@ $(TRACE_PROGRAMS): %.trace: phony
 	$(MPL) $(FLAGS) $(TRACE_FLAGS) -output bin/$*.trace src/$*/sources.mlb
 	@echo "successfully built bin/$*.trace"
 
-$(DETECT_PROGRAMS): %.detect: phony
+$(NODETECT_PROGRAMS): %.nodetect: phony
 	@mkdir -p bin
-	$(MPL) $(FLAGS) $(DETECT_FLAGS) -output bin/$*.detect src/$*/sources.mlb
-	@echo "successfully built bin/$*.detect"
+	$(MPL) $(FLAGS) $(NODETECT_FLAGS) -output bin/$*.nodetect src/$*/sources.mlb
+	@echo "successfully built bin/$*.nodetect"
 
 $(SYSMPL_PROGRAMS): %.sysmpl: phony
 	@mkdir -p bin

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -296,12 +296,12 @@ val defaultWord = control {name = "defaultWord",
 
 val detectEntanglement =
   control {name = "detect-entanglement",
-           default = false,
+           default = true,
            toString = Bool.toString}
 
 val detectEntanglementRuntime =
   control {name = "detect-entanglement-runtime",
-           default = false,
+           default = true,
            toString = Bool.toString}
 
 val diagPasses =

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -13,6 +13,15 @@ void CC_workList_init(
   w->currentChunk = HM_allocateChunk(c, sizeof(struct CC_workList_elem));
 }
 
+void CC_workList_free(
+    __attribute__((unused)) GC_state s,
+    CC_workList w)
+{
+
+  HM_chunkList c = &(w->storage);
+  HM_freeChunksInListWithInfo(s, c, NULL);
+  w->currentChunk = NULL;
+}
 
 bool CC_workList_isEmpty(
   __attribute__((unused)) GC_state s,

--- a/runtime/gc/cc-work-list.h
+++ b/runtime/gc/cc-work-list.h
@@ -42,6 +42,7 @@ typedef struct CC_workList_range * CC_workList_range;
 
 bool CC_workList_isEmpty(GC_state s, CC_workList w);
 void CC_workList_init(GC_state s, CC_workList w);
+void CC_workList_free(GC_state s, CC_workList w);
 void CC_workList_push(GC_state s, CC_workList w, objptr op);
 
 /** Returns a single field of an object that still needs to be traced.

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -1042,6 +1042,7 @@ size_t CC_collectWithRoots(
   HM_freeChunksInList(s, removedFromCCBag);
 
   assert(CC_workList_isEmpty(s, &(lists.worklist)));
+  CC_workList_free(s, &(lists.worklist));
 
 #if ASSERT2 // just contains code that is sometimes useful for debugging.
   HM_assertChunkListInvariants(origList);


### PR DESCRIPTION
This patch enables entanglement detection by default, which has nearly zero overhead (see #154) for most of our benchmarks.