### PR TITLE
Some runtime controls for CGC

### DIFF
--- a/basis-library/mpl/gc.sig
+++ b/basis-library/mpl/gc.sig
@@ -24,6 +24,8 @@ sig
   val numberSuspectsMarked: unit -> IntInf.int
   val numberSuspectsCleared: unit -> IntInf.int
 
+  val getControlMaxCCDepth: unit -> int
+
   (* The following are all cumulative statistics (initially 0, and only
    * increase throughout execution).
    *

--- a/basis-library/mpl/gc.sml
+++ b/basis-library/mpl/gc.sml
@@ -43,6 +43,9 @@ struct
     fun numberEntanglementsDetected () =
       C_UIntmax.toLargeInt (GC.numberEntanglementsDetected (gcState ()))
 
+    fun getControlMaxCCDepth () =
+      Word32.toInt (GC.getControlMaxCCDepth (gcState ()))
+
     fun numberSuspectsMarked () =
       C_UIntmax.toLargeInt (GC.numberSuspectsMarked (gcState ()))
 

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -149,6 +149,8 @@ structure GC =
       val setSummary = _import "GC_setControlsSummary" private: GCState.t * bool -> unit;
       val unpack = _import "GC_unpack" runtime private: GCState.t -> unit;
 
+      val getControlMaxCCDepth = _import "GC_getControlMaxCCDepth" runtime private: GCState.t -> Word32.word;
+
       (* SAM_NOTE: TODO: move these to prim-mpl.sml *)
       val getLocalGCMillisecondsOfProc = _import "GC_getLocalGCMillisecondsOfProc" runtime private : GCState.t * Word32.word -> C_UIntmax.t;
       val getPromoMillisecondsOfProc = _import "GC_getPromoMillisecondsOfProc" runtime private : GCState.t * Word32.word -> C_UIntmax.t;

--- a/basis-library/schedulers/shh/Scheduler.sml
+++ b/basis-library/schedulers/shh/Scheduler.sml
@@ -43,6 +43,8 @@ struct
     | SOME m => depth < m
   end
 
+  val maxCCDepth = MPL.GC.getControlMaxCCDepth ()
+
   val P = MLton.Parallel.numberOfProcessors
   val internalGCThresh = Real.toInt IEEEReal.TO_POSINF
                           ((Math.log10(Real.fromInt P)) / (Math.log10 (2.0)))
@@ -426,7 +428,7 @@ struct
         val depth = HH.getDepth thread
       in
         (* if ccOkayAtThisDepth andalso depth = 1 then *)
-        if ccOkayAtThisDepth andalso depth >= 1 andalso depth <= 3 then
+        if ccOkayAtThisDepth andalso depth >= 1 andalso depth <= maxCCDepth then
           forkGC thread depth (f, g)
         else if depth < Queue.capacity andalso depthOkayForDECheck depth then
           parfork thread depth (f, g)

--- a/basis-library/schedulers/shh/sources.mlb
+++ b/basis-library/schedulers/shh/sources.mlb
@@ -1,6 +1,7 @@
 local
   $(SML_LIB)/basis/basis.mlb
   $(SML_LIB)/basis/mlton.mlb
+  $(SML_LIB)/basis/mpl.mlb
   $(SML_LIB)/basis/unsafe.mlb
 
   local

--- a/runtime/gc/controls.h
+++ b/runtime/gc/controls.h
@@ -36,6 +36,7 @@ struct HM_HierarchicalHeapConfig {
 
   size_t maxCCChainLength;
   double ccThresholdRatio;
+  uint32_t maxCCDepth;
 
   /* the shallowest depth that will be claimed for a local
    * collection. */

--- a/runtime/gc/controls.h
+++ b/runtime/gc/controls.h
@@ -35,6 +35,7 @@ struct HM_HierarchicalHeapConfig {
   size_t minCCSize;
 
   size_t maxCCChainLength;
+  double ccThresholdRatio;
 
   /* the shallowest depth that will be claimed for a local
    * collection. */

--- a/runtime/gc/controls.h
+++ b/runtime/gc/controls.h
@@ -34,6 +34,8 @@ struct HM_HierarchicalHeapConfig {
   /* smallest amount for a CC */
   size_t minCCSize;
 
+  size_t maxCCChainLength;
+
   /* the shallowest depth that will be claimed for a local
    * collection. */
   uint32_t minLocalDepth;

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -77,6 +77,10 @@ void GC_setControlsRusageMeasureGC (GC_state s, Bool_t b) {
   s->controls->rusageMeasureGC = (bool)b;
 }
 
+uint32_t GC_getControlMaxCCDepth(GC_state s) {
+  return (uint32_t)s->controls->hhConfig.maxCCDepth;
+}
+
 // SAM_NOTE: TODO: remove this and replace with blocks statistics
 size_t GC_getMaxChunkPoolOccupancy (void) {
   return 0;

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -143,6 +143,8 @@ PRIVATE uintmax_t GC_numChecksSkipped(GC_state s);
 PRIVATE uintmax_t GC_numSuspectsMarked(GC_state s);
 PRIVATE uintmax_t GC_numSuspectsCleared(GC_state s);
 
+PRIVATE uint32_t GC_getControlMaxCCDepth(GC_state s);
+
 PRIVATE pointer GC_getCallFromCHandlerThread (GC_state s);
 PRIVATE void GC_setCallFromCHandlerThreads (GC_state s, pointer p);
 PRIVATE pointer GC_getCurrentThread (GC_state s);

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -804,7 +804,7 @@ bool checkPolicyforRoot(
        cursor = cursor->subHeapForCC)
   {
     chainLen++;
-    if (chainLen > 2)
+    if (chainLen > s->controls->hhConfig.maxCCChainLength)
       return FALSE;
   }
 

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -817,7 +817,7 @@ bool checkPolicyforRoot(
       HM_HH_getConcurrentPack(cursor)->bytesSurvivedLastCollection;
   }
 
-  if((2*bytesSurvived) >
+  if((s->controls->hhConfig.ccThresholdRatio * bytesSurvived) >
       (HM_HH_getConcurrentPack(hh)->bytesAllocatedSinceLastCollection)
     || bytesSurvived == 0) {
     // if (!HM_HH_getConcurrentPack(hh)->shouldCollect) {

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -369,6 +369,17 @@ int processAtMLton (GC_state s, int start, int argc, char **argv,
           }
 
           s->controls->hhConfig.minCCSize = stringToBytes(argv[i++]);
+        } else if (0 == strcmp(arg, "max-cc-chain-length")) {
+          i++;
+          if (i == argc || (0 == strcmp (argv[i], "--"))) {
+            die ("%s max-cc-chain-length missing argument.", atName);
+          }
+
+          int len = stringToInt(argv[i++]);
+          if (len <= 0) {
+            die ("%s max-cc-chain-length must be >= 1", atName);
+          }
+          s->controls->hhConfig.maxCCChainLength = len;
         } else if (0 == strcmp(arg, "min-collection-depth")) {
           i++;
           if (i == argc || (0 == strcmp (argv[i], "--"))) {
@@ -434,6 +445,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->controls->hhConfig.collectionThresholdRatio = 8.0;
   s->controls->hhConfig.minCollectionSize = 1024L * 1024L;
   s->controls->hhConfig.minCCSize = 1024L * 1024L;
+  s->controls->hhConfig.maxCCChainLength = 2;
   s->controls->hhConfig.minLocalDepth = 2;
   s->controls->rusageMeasureGC = FALSE;
   s->controls->summary = FALSE;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -355,6 +355,16 @@ int processAtMLton (GC_state s, int start, int argc, char **argv,
           if (s->controls->hhConfig.collectionThresholdRatio < 1.0) {
             die("%s collection-threshold-ratio must be at least 1.0", atName);
           }
+        } else if (0 == strcmp (arg, "cc-threshold-ratio")) {
+          i++;
+          if (i == argc || (0 == strcmp (argv[i], "--"))) {
+            die ("%s cc-threshold-ratio missing argument.", atName);
+          }
+
+          s->controls->hhConfig.ccThresholdRatio = stringToFloat(argv[i++]);
+          if (s->controls->hhConfig.ccThresholdRatio <= 1.0) {
+            die("%s cc-threshold-ratio must be > 1.0", atName);
+          }
         } else if (0 == strcmp(arg, "min-collection-size")) {
           i++;
           if (i == argc || (0 == strcmp (argv[i], "--"))) {
@@ -446,6 +456,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->controls->hhConfig.minCollectionSize = 1024L * 1024L;
   s->controls->hhConfig.minCCSize = 1024L * 1024L;
   s->controls->hhConfig.maxCCChainLength = 2;
+  s->controls->hhConfig.ccThresholdRatio = 2.0f;
   s->controls->hhConfig.minLocalDepth = 2;
   s->controls->rusageMeasureGC = FALSE;
   s->controls->summary = FALSE;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -401,6 +401,17 @@ int processAtMLton (GC_state s, int start, int argc, char **argv,
             die ("%s min-collection-depth must be > 0", atName);
           }
           s->controls->hhConfig.minLocalDepth = minDepth;
+        } else if (0 == strcmp(arg, "max-cc-depth")) {
+          i++;
+          if (i == argc || (0 == strcmp (argv[i], "--"))) {
+            die ("%s max-cc-depth missing argument.", atName);
+          }
+
+          int maxd = stringToInt(argv[i++]);
+          if (maxd < 0) {
+            die ("%s max-cc-depth must be >= 0", atName);
+          }
+          s->controls->hhConfig.maxCCDepth = maxd;
         } else if (0 == strcmp(arg, "trace-buffer-size")) {
           i++;
           if (i == argc || (0 == strcmp (argv[i], "--"))) {
@@ -457,6 +468,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->controls->hhConfig.minCCSize = 1024L * 1024L;
   s->controls->hhConfig.maxCCChainLength = 2;
   s->controls->hhConfig.ccThresholdRatio = 2.0f;
+  s->controls->hhConfig.maxCCDepth = 3;
   s->controls->hhConfig.minLocalDepth = 2;
   s->controls->rusageMeasureGC = FALSE;
   s->controls->summary = FALSE;


### PR DESCRIPTION
Adds three `@mpl ... --` runtime settings for CGC:
  - `max-cc-depth`: max depth allowed for a CGC. Default is `3`. Increasing this enlarges the scope of CGC, the impact of which is not clear yet. In general, we recommend keeping CGC shallow.
  - `cc-threshold-ratio`: max allowable current-size/survived ratio for CGC. Default is `2.0` (very eager). Increasing this will increase space usage, and decrease the total amount of work performed by CGC.
  - `max-cc-chain-length`: max number of simultaneous CGCs allowed per heap. Default `2`. The impact of this isn't clear yet (should do some experiments)