### PR TITLE
Block statistics

### DIFF
--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -95,6 +95,7 @@ extern C_Pthread_Key_t gcstate_key;
 #include "gc/concurrent-list.c"
 #include "gc/remembered-set.c"
 #include "gc/rusage.c"
+#include "gc/sampler.c"
 #include "gc/sequence-allocate.c"
 #include "gc/sequence.c"
 #include "gc/share.c"

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -27,6 +27,7 @@ typedef GC_state GCState_t;
 
 #include "gc/debug.h"
 #include "gc/logger.h"
+#include "gc/sampler.h"
 #include "gc/block-allocator.h"
 
 #include "gc/tls-objects.h"

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -706,8 +706,10 @@ void logCurrentBlockUsage(GC_state s) {
     "  total mmap'ed              %zu\n"
     "  BLOCK_FOR_HEAP_CHUNK       %zu (%zu%%)\n"
     "  BLOCK_FOR_REMEMBERED_SET   %zu (%zu%%)\n"
+    "  BLOCK_FOR_FORGOTTEN_SET    %zu (%zu%%)\n"
     "  BLOCK_FOR_HH_ALLOCATOR     %zu (%zu%%)\n"
     "  BLOCK_FOR_UF_ALLOCATOR     %zu (%zu%%)\n"
+    "  BLOCK_FOR_GC_WORKLIST      %zu (%zu%%)\n"
     "  BLOCK_FOR_UNKNOWN_PURPOSE  %zu (%zu%%)\n",
     now.tv_sec,
     now.tv_nsec,
@@ -719,11 +721,17 @@ void logCurrentBlockUsage(GC_state s) {
     inUse[BLOCK_FOR_REMEMBERED_SET],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_REMEMBERED_SET] / (double)count),
 
+    inUse[BLOCK_FOR_FORGOTTEN_SET],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_FORGOTTEN_SET] / (double)count),
+
     inUse[BLOCK_FOR_HH_ALLOCATOR],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_HH_ALLOCATOR] / (double)count),
 
     inUse[BLOCK_FOR_UF_ALLOCATOR],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UF_ALLOCATOR] / (double)count),
+
+    inUse[BLOCK_FOR_GC_WORKLIST],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_GC_WORKLIST] / (double)count),
 
     inUse[BLOCK_FOR_UNKNOWN_PURPOSE],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN_PURPOSE] / (double)count));

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -705,12 +705,18 @@ void logCurrentBlockUsage(GC_state s) {
     "block-allocator(%zu.%.9zu):\n"
     "  total mmap'ed             %zu\n"
     "  BLOCK_FOR_HEAP_CHUNK      %zu (%zu%%)\n"
+    "  BLOCK_FOR_HH_ALLOCATOR    %zu (%zu%%)\n"
+    "  BLOCK_FOR_UF_ALLOCATOR    %zu (%zu%%)\n"
     "  BLOCK_FOR_UNKNOWN_PURPOSE %zu (%zu%%)\n",
     now.tv_sec,
     now.tv_nsec,
     count,
     inUse[BLOCK_FOR_HEAP_CHUNK],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_HEAP_CHUNK] / (double)count),
+    inUse[BLOCK_FOR_HH_ALLOCATOR],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_HH_ALLOCATOR] / (double)count),
+    inUse[BLOCK_FOR_UF_ALLOCATOR],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_UF_ALLOCATOR] / (double)count),
     inUse[BLOCK_FOR_UNKNOWN_PURPOSE],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN_PURPOSE] / (double)count));
 }

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -718,6 +718,8 @@ void logCurrentBlockUsage(
     "  BLOCK_FOR_HH_ALLOCATOR     %zu (%zu%%) (= %zu - %zu)\n"
     "  BLOCK_FOR_UF_ALLOCATOR     %zu (%zu%%) (= %zu - %zu)\n"
     "  BLOCK_FOR_GC_WORKLIST      %zu (%zu%%) (= %zu - %zu)\n"
+    "  BLOCK_FOR_SUSPECTS         %zu (%zu%%) (= %zu - %zu)\n"
+    "  BLOCK_FOR_EBR              %zu (%zu%%) (= %zu - %zu)\n"
     "  BLOCK_FOR_UNKNOWN_PURPOSE  %zu (%zu%%) (= %zu - %zu)\n",
     now->tv_sec,
     now->tv_nsec,
@@ -754,6 +756,16 @@ void logCurrentBlockUsage(
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_GC_WORKLIST] / (double)count),
     allocated[BLOCK_FOR_GC_WORKLIST],
     freed[BLOCK_FOR_GC_WORKLIST],
+
+    inUse[BLOCK_FOR_SUSPECTS],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_SUSPECTS] / (double)count),
+    allocated[BLOCK_FOR_SUSPECTS],
+    freed[BLOCK_FOR_SUSPECTS],
+
+    inUse[BLOCK_FOR_EBR],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_EBR] / (double)count),
+    allocated[BLOCK_FOR_EBR],
+    freed[BLOCK_FOR_EBR],
 
     inUse[BLOCK_FOR_UNKNOWN_PURPOSE],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN_PURPOSE] / (double)count),

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -566,7 +566,7 @@ Blocks allocateBlocksWithPurpose(GC_state s, size_t numBlocks, enum BlockPurpose
 
 
 Blocks allocateBlocks(GC_state s, size_t numBlocks) {
-  return allocateBlocksWithPurpose(s, numBlocks, BLOCK_FOR_UNKNOWN);
+  return allocateBlocksWithPurpose(s, numBlocks, BLOCK_FOR_UNKNOWN_PURPOSE);
 }
 
 
@@ -685,12 +685,12 @@ void logCurrentBlockUsage(GC_state s) {
   LOG(LM_BLOCK_ALLOCATOR, LL_INFO,
     "block-allocator(%zu.%.9zu):\n"
     "  total mmap'ed     %zu\n"
-    "  BLOCK_FOR_UNKNOWN %zu (%zu%%)",
+    "  BLOCK_FOR_UNKNOWN_PURPOSE %zu (%zu%%)",
     now.tv_sec,
     now.tv_nsec,
     count,
-    inUse[BLOCK_FOR_UNKNOWN],
-    (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN] / (double)count));
+    inUse[BLOCK_FOR_UNKNOWN_PURPOSE],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN_PURPOSE] / (double)count));
 }
 
 #endif

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -768,10 +768,7 @@ Sampler newBlockUsageSampler(GC_state s) {
   func.fun = logCurrentBlockUsage;
   func.env = NULL;
 
-  struct timespec desiredInterval;
-  desiredInterval.tv_sec = 0;
-  desiredInterval.tv_nsec = 1000000; // 1 ms
-
+  struct timespec desiredInterval = s->controls->blockUsageSampleInterval;
   Sampler result = malloc(sizeof(struct Sampler));
   initSampler(s, result, &func, &desiredInterval);
 

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -703,20 +703,28 @@ void logCurrentBlockUsage(GC_state s) {
   timespec_now(&now);
   LOG(LM_BLOCK_ALLOCATOR, LL_INFO,
     "block-allocator(%zu.%.9zu):\n"
-    "  total mmap'ed             %zu\n"
-    "  BLOCK_FOR_HEAP_CHUNK      %zu (%zu%%)\n"
-    "  BLOCK_FOR_HH_ALLOCATOR    %zu (%zu%%)\n"
-    "  BLOCK_FOR_UF_ALLOCATOR    %zu (%zu%%)\n"
-    "  BLOCK_FOR_UNKNOWN_PURPOSE %zu (%zu%%)\n",
+    "  total mmap'ed              %zu\n"
+    "  BLOCK_FOR_HEAP_CHUNK       %zu (%zu%%)\n"
+    "  BLOCK_FOR_REMEMBERED_SET   %zu (%zu%%)\n"
+    "  BLOCK_FOR_HH_ALLOCATOR     %zu (%zu%%)\n"
+    "  BLOCK_FOR_UF_ALLOCATOR     %zu (%zu%%)\n"
+    "  BLOCK_FOR_UNKNOWN_PURPOSE  %zu (%zu%%)\n",
     now.tv_sec,
     now.tv_nsec,
     count,
+
     inUse[BLOCK_FOR_HEAP_CHUNK],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_HEAP_CHUNK] / (double)count),
+
+    inUse[BLOCK_FOR_REMEMBERED_SET],
+    (size_t)(100.0 * (double)inUse[BLOCK_FOR_REMEMBERED_SET] / (double)count),
+
     inUse[BLOCK_FOR_HH_ALLOCATOR],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_HH_ALLOCATOR] / (double)count),
+
     inUse[BLOCK_FOR_UF_ALLOCATOR],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UF_ALLOCATOR] / (double)count),
+
     inUse[BLOCK_FOR_UNKNOWN_PURPOSE],
     (size_t)(100.0 * (double)inUse[BLOCK_FOR_UNKNOWN_PURPOSE] / (double)count));
 }

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -193,6 +193,10 @@ Blocks allocateBlocks(GC_state s, size_t numBlocks);
 
 Blocks allocateBlocksWithPurpose(GC_state s, size_t numBlocks, enum BlockPurpose purpose);
 
+/** Free a group of contiguous blocks. */
+void freeBlocks(GC_state s, Blocks bs, writeFreedBlockInfoFnClosure f);
+
+
 /** populate:
   *   *numBlocks := current total number of blocks mmap'ed
   *   blocksInUseArr[p] := current number of blocks allocated for purpose `p`
@@ -201,10 +205,7 @@ Blocks allocateBlocksWithPurpose(GC_state s, size_t numBlocks, enum BlockPurpose
   */
 void queryCurrentBlockUsage(GC_state s, size_t *numBlocks, size_t *blocksInUseArr);
 
-void logCurrentBlockUsage(GC_state s);
-
-/** Free a group of contiguous blocks. */
-void freeBlocks(GC_state s, Blocks bs, writeFreedBlockInfoFnClosure f);
+Sampler newBlockUsageSampler(GC_state s);
 
 #endif
 

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -22,6 +22,7 @@ enum BlockPurpose {
   BLOCK_FOR_FORGOTTEN_SET,
   BLOCK_FOR_HH_ALLOCATOR,
   BLOCK_FOR_UF_ALLOCATOR,
+  BLOCK_FOR_GC_WORKLIST,
   BLOCK_FOR_UNKNOWN_PURPOSE,
   NUM_BLOCK_PURPOSES /** Hack to know statically how many there are. Make sure
                        * this comes last in the list. */

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -23,6 +23,8 @@ enum BlockPurpose {
   BLOCK_FOR_HH_ALLOCATOR,
   BLOCK_FOR_UF_ALLOCATOR,
   BLOCK_FOR_GC_WORKLIST,
+  BLOCK_FOR_SUSPECTS,
+  BLOCK_FOR_EBR,
   BLOCK_FOR_UNKNOWN_PURPOSE,
   NUM_BLOCK_PURPOSES /** Hack to know statically how many there are. Make sure
                        * this comes last in the list. */

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -138,8 +138,10 @@ enum FullnessGroup {
 
 typedef struct BlockAllocator {
 
-  size_t numBlocks;
-  size_t numBlocksInUse[NUM_BLOCK_PURPOSES];
+  size_t numBlocksMapped;
+  size_t numBlocksReleased;
+  size_t numBlocksAllocated[NUM_BLOCK_PURPOSES];
+  size_t numBlocksFreed[NUM_BLOCK_PURPOSES];
 
   /** There are 3 fullness groups in each size class:
     *   0 is completely full, i.e. no free blocks available
@@ -199,11 +201,17 @@ void freeBlocks(GC_state s, Blocks bs, writeFreedBlockInfoFnClosure f);
 
 /** populate:
   *   *numBlocks := current total number of blocks mmap'ed
-  *   blocksInUseArr[p] := current number of blocks allocated for purpose `p`
+  *   blocksAllocated[p] := cumulative number of blocks allocated for purpose `p`
+  *   blocksFreed[p] := cumulative number of blocks freed for purpose `p`
   *
-  * The `blocksInUseArr` must be an array of length `NUM_BLOCK_PURPOSES`
+  * The `blocksAllocated` and `blocksFreed` arrays must have length `NUM_BLOCK_PURPOSES`
   */
-void queryCurrentBlockUsage(GC_state s, size_t *numBlocks, size_t *blocksInUseArr);
+void queryCurrentBlockUsage(
+  GC_state s,
+  size_t *numBlocksMapped,
+  size_t *numBlocksReleased,
+  size_t *blocksAllocated,
+  size_t *blocksFreed);
 
 Sampler newBlockUsageSampler(GC_state s);
 

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -22,7 +22,7 @@ enum BlockPurpose {
   BLOCK_FOR_FORGOTTEN_SET,
   BLOCK_FOR_HH_ALLOCATOR,
   BLOCK_FOR_UF_ALLOCATOR,
-  BLOCK_FOR_UNKNOWN,
+  BLOCK_FOR_UNKNOWN_PURPOSE,
   NUM_BLOCK_PURPOSES /** Hack to know statically how many there are. Make sure
                        * this comes last in the list. */
 };

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -10,7 +10,10 @@ void CC_workList_init(
   HM_chunkList c = &(w->storage);
   HM_initChunkList(c);
   // arbitrary, just need an initial chunk
-  w->currentChunk = HM_allocateChunk(c, sizeof(struct CC_workList_elem));
+  w->currentChunk = HM_allocateChunkWithPurpose(
+    c,
+    sizeof(struct CC_workList_elem),
+    BLOCK_FOR_GC_WORKLIST);
 }
 
 void CC_workList_free(
@@ -18,7 +21,7 @@ void CC_workList_free(
     CC_workList w)
 {
   HM_chunkList c = &(w->storage);
-  HM_freeChunksInListWithInfo(s, c, NULL, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunksInListWithInfo(s, c, NULL, BLOCK_FOR_GC_WORKLIST);
   w->currentChunk = NULL;
 }
 
@@ -297,7 +300,7 @@ objptr* CC_workList_pop(
     if (NULL != chunk->nextChunk) {
       HM_chunk nextChunk = chunk->nextChunk;
       HM_unlinkChunk(list, nextChunk);
-      HM_freeChunk(s, nextChunk);
+      HM_freeChunkWithInfo(s, nextChunk, NULL, BLOCK_FOR_GC_WORKLIST);
     }
 
     assert(NULL == chunk->nextChunk);

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -18,7 +18,7 @@ void CC_workList_free(
     CC_workList w)
 {
   HM_chunkList c = &(w->storage);
-  HM_freeChunksInListWithInfo(s, c, NULL);
+  HM_freeChunksInListWithInfo(s, c, NULL, BLOCK_FOR_UNKNOWN_PURPOSE);
   w->currentChunk = NULL;
 }
 

--- a/runtime/gc/cc-work-list.c
+++ b/runtime/gc/cc-work-list.c
@@ -139,7 +139,11 @@ void CC_workList_push(
     if (chunk->nextChunk != NULL) {
       chunk = chunk->nextChunk; // this will be an empty chunk
     } else {
-      chunk = HM_allocateChunk(list, elemSize);
+      // chunk = HM_allocateChunk(list, elemSize);
+      chunk = HM_allocateChunkWithPurpose(
+        list,
+        elemSize,
+        BLOCK_FOR_GC_WORKLIST);
     }
     w->currentChunk = chunk;
   }

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -199,6 +199,7 @@ void HM_freeChunkWithInfo(
   Blocks bs = (Blocks)chunk;
   bs->numBlocks = numBlocks;
   bs->container = container;
+  bs->purpose = BLOCK_FOR_UNKNOWN;
   freeBlocks(s, bs, &c);
 }
 

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -119,11 +119,11 @@ HM_chunk HM_initializeChunk(pointer start, pointer end) {
 }
 
 
-HM_chunk HM_getFreeChunk(GC_state s, size_t bytesRequested) {
+HM_chunk HM_getFreeChunkWithPurpose(GC_state s, size_t bytesRequested, enum BlockPurpose purpose) {
   size_t chunkWidth =
     align(bytesRequested + sizeof(struct HM_chunk), HM_BLOCK_SIZE);
   size_t numBlocks = chunkWidth / HM_BLOCK_SIZE;
-  Blocks start = allocateBlocks(s, numBlocks);
+  Blocks start = allocateBlocksWithPurpose(s, numBlocks, purpose);
   SuperBlock container = start->container;
   numBlocks = start->numBlocks;
   HM_chunk result =
@@ -131,6 +131,11 @@ HM_chunk HM_getFreeChunk(GC_state s, size_t bytesRequested) {
   result->container = container;
   result->numBlocks = numBlocks;
   return result;
+}
+
+
+HM_chunk HM_getFreeChunk(GC_state s, size_t bytesRequested) {
+  return HM_getFreeChunkWithPurpose(s, bytesRequested, BLOCK_FOR_UNKNOWN_PURPOSE);
 }
 
 
@@ -174,7 +179,8 @@ void writeChunkInfo(
 void HM_freeChunkWithInfo(
   GC_state s,
   HM_chunk chunk,
-  writeFreedBlockInfoFnClosure f)
+  writeFreedBlockInfoFnClosure f,
+  enum BlockPurpose purpose)
 {
 
   struct writeChunkInfoArgs args;
@@ -199,35 +205,40 @@ void HM_freeChunkWithInfo(
   Blocks bs = (Blocks)chunk;
   bs->numBlocks = numBlocks;
   bs->container = container;
-  bs->purpose = BLOCK_FOR_UNKNOWN;
+  bs->purpose = purpose;
   freeBlocks(s, bs, &c);
 }
 
 void HM_freeChunk(GC_state s, HM_chunk chunk) {
-  HM_freeChunkWithInfo(s, chunk, NULL);
+  HM_freeChunkWithInfo(s, chunk, NULL, BLOCK_FOR_UNKNOWN_PURPOSE);
 }
 
 void HM_freeChunksInListWithInfo(
   GC_state s,
   HM_chunkList list,
-  writeFreedBlockInfoFnClosure f)
+  writeFreedBlockInfoFnClosure f,
+  enum BlockPurpose purpose)
 {
   HM_chunk chunk = list->firstChunk;
   while (chunk != NULL) {
     HM_chunk next = chunk->nextChunk;
-    HM_freeChunkWithInfo(s, chunk, f);
+    HM_freeChunkWithInfo(s, chunk, f, purpose);
     chunk = next;
   }
   HM_initChunkList(list);
 }
 
 void HM_freeChunksInList(GC_state s, HM_chunkList list) {
-  HM_freeChunksInListWithInfo(s, list, NULL);
+  HM_freeChunksInListWithInfo(s, list, NULL, BLOCK_FOR_UNKNOWN_PURPOSE);
 }
 
-HM_chunk HM_allocateChunk(HM_chunkList list, size_t bytesRequested) {
+HM_chunk HM_allocateChunkWithPurpose(
+  HM_chunkList list,
+  size_t bytesRequested,
+  enum BlockPurpose purpose)
+{
   GC_state s = pthread_getspecific(gcstate_key);
-  HM_chunk chunk = HM_getFreeChunk(s, bytesRequested);
+  HM_chunk chunk = HM_getFreeChunkWithPurpose(s, bytesRequested, purpose);
 
   if (NULL == chunk) {
     DIE("Out of memory. Unable to allocate chunk of size %zu.",
@@ -245,6 +256,12 @@ HM_chunk HM_allocateChunk(HM_chunkList list, size_t bytesRequested) {
 
   return chunk;
 }
+
+
+HM_chunk HM_allocateChunk(HM_chunkList list, size_t bytesRequested) {
+  return HM_allocateChunkWithPurpose(list, bytesRequested, BLOCK_FOR_UNKNOWN_PURPOSE);
+}
+
 
 void HM_initChunkList(HM_chunkList list) {
   list->firstChunk = NULL;

--- a/runtime/gc/chunk.c
+++ b/runtime/gc/chunk.c
@@ -493,10 +493,10 @@ size_t HM_getChunkListUsedSize(HM_chunkList list) {
   return list->usedSize;
 }
 
-pointer HM_storeInchunkList(HM_chunkList chunkList, void* p, size_t objSize) {
+pointer HM_storeInChunkListWithPurpose(HM_chunkList chunkList, void* p, size_t objSize, enum BlockPurpose purpose) {
   HM_chunk chunk = HM_getChunkListLastChunk(chunkList);
   if (NULL == chunk || HM_getChunkSizePastFrontier(chunk) < objSize) {
-    chunk = HM_allocateChunk(chunkList, objSize);
+    chunk = HM_allocateChunkWithPurpose(chunkList, objSize, purpose);
   }
 
   assert(NULL != chunk);
@@ -509,6 +509,10 @@ pointer HM_storeInchunkList(HM_chunkList chunkList, void* p, size_t objSize) {
 
   memcpy(frontier, p, objSize);
   return frontier;
+}
+
+pointer HM_storeInChunkList(HM_chunkList chunkList, void* p, size_t objSize) {
+  return HM_storeInChunkListWithPurpose(chunkList, p, objSize, BLOCK_FOR_UNKNOWN_PURPOSE);
 }
 
 HM_HierarchicalHeap HM_getLevelHead(HM_chunk chunk) {

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -266,7 +266,8 @@ pointer HM_shiftChunkStart(HM_chunk chunk, size_t bytes);
 pointer HM_getChunkStartGap(HM_chunk chunk);
 
 /* store the object pointed by p at the end of list and return the address */
-pointer HM_storeInchunkList(HM_chunkList chunkList, void* p, size_t objSize);
+pointer HM_storeInChunkList(HM_chunkList chunkList, void* p, size_t objSize);
+pointer HM_storeInchunkListWithPurpose(HM_chunkList chunkList, void* p, size_t objSize, enum BlockPurpose purpose);
 
 
 /**

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -156,6 +156,7 @@ HM_chunk HM_getFreeChunk(GC_state s, size_t bytesRequested);
  *   chunk->limit - chunk->frontier <= bytesRequested
  * Returns NULL if unable to find space for such a chunk. */
 HM_chunk HM_allocateChunk(HM_chunkList list, size_t bytesRequested);
+HM_chunk HM_allocateChunkWithPurpose(HM_chunkList list, size_t bytesRequested, enum BlockPurpose purpose);
 
 void HM_initChunkList(HM_chunkList list);
 

--- a/runtime/gc/chunk.h
+++ b/runtime/gc/chunk.h
@@ -162,8 +162,8 @@ void HM_initChunkList(HM_chunkList list);
 void HM_freeChunk(GC_state s, HM_chunk chunk);
 void HM_freeChunksInList(GC_state s, HM_chunkList list);
 
-void HM_freeChunkWithInfo(GC_state s, HM_chunk chunk, writeFreedBlockInfoFnClosure f);
-void HM_freeChunksInListWithInfo(GC_state s, HM_chunkList list, writeFreedBlockInfoFnClosure f);
+void HM_freeChunkWithInfo(GC_state s, HM_chunk chunk, writeFreedBlockInfoFnClosure f, enum BlockPurpose purpose);
+void HM_freeChunksInListWithInfo(GC_state s, HM_chunkList list, writeFreedBlockInfoFnClosure f, enum BlockPurpose purpose);
 
 // void HM_deleteChunks(GC_state s, HM_chunkList deleteList);
 void HM_appendChunkList(HM_chunkList destinationChunkList, HM_chunkList chunkList);

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -1064,7 +1064,7 @@ size_t CC_collectWithRoots(
   forEachObjptrInCCStackBag(s, removedFromCCBag, tryUnmarkAndUnmarkLoop, &lists);
   unmarkLoop(s, &lists);
 
-  HM_freeChunksInList(s, removedFromCCBag);
+  HM_freeChunksInListWithInfo(s, removedFromCCBag, NULL, BLOCK_FOR_FORGOTTEN_SET);
 
   assert(CC_workList_isEmpty(s, &(lists.worklist)));
   CC_workList_free(s, &(lists.worklist));

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -865,7 +865,7 @@ void CC_filterPinned(
 
   // HM_freeRemSetWithInfo(s, oldRemSet, &infoc);
   // this reintializes the private remset
-  HM_freeChunksInListWithInfo(s, &(oldRemSet->private), &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunksInListWithInfo(s, &(oldRemSet->private), &infoc, BLOCK_FOR_REMEMBERED_SET);
   assert (newRemSet.public.firstChunk == NULL);
   // this moves all data into remset of hh
   HM_appendRemSet(oldRemSet, &newRemSet);
@@ -1151,8 +1151,8 @@ size_t CC_collectWithRoots(
   /** SAM_NOTE: TODO: deleteList no longer needed, because
     * block allocator handles that.
     */
-  HM_freeChunksInListWithInfo(s, origList, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
-  HM_freeChunksInListWithInfo(s, deleteList, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunksInListWithInfo(s, origList, &infoc, BLOCK_FOR_HEAP_CHUNK);
+  HM_freeChunksInListWithInfo(s, deleteList, &infoc, BLOCK_FOR_HEAP_CHUNK);
 
   for(HM_chunk chunk = repList->firstChunk;
     chunk!=NULL; chunk = chunk->nextChunk) {
@@ -1168,7 +1168,7 @@ size_t CC_collectWithRoots(
   assert(isChunkInList(stackChunk, origList));
   HM_unlinkChunk(origList, stackChunk);
   info.freedType = CC_FREED_STACK_CHUNK;
-  HM_freeChunkWithInfo(s, stackChunk, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunkWithInfo(s, stackChunk, &infoc, BLOCK_FOR_HEAP_CHUNK);
   info.freedType = CC_FREED_NORMAL_CHUNK;
   cp->stack = BOGUS_OBJPTR;
 

--- a/runtime/gc/concurrent-collection.c
+++ b/runtime/gc/concurrent-collection.c
@@ -865,7 +865,7 @@ void CC_filterPinned(
 
   // HM_freeRemSetWithInfo(s, oldRemSet, &infoc);
   // this reintializes the private remset
-  HM_freeChunksInListWithInfo(s, &(oldRemSet->private), &infoc);
+  HM_freeChunksInListWithInfo(s, &(oldRemSet->private), &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
   assert (newRemSet.public.firstChunk == NULL);
   // this moves all data into remset of hh
   HM_appendRemSet(oldRemSet, &newRemSet);
@@ -1151,8 +1151,8 @@ size_t CC_collectWithRoots(
   /** SAM_NOTE: TODO: deleteList no longer needed, because
     * block allocator handles that.
     */
-  HM_freeChunksInListWithInfo(s, origList, &infoc);
-  HM_freeChunksInListWithInfo(s, deleteList, &infoc);
+  HM_freeChunksInListWithInfo(s, origList, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunksInListWithInfo(s, deleteList, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
 
   for(HM_chunk chunk = repList->firstChunk;
     chunk!=NULL; chunk = chunk->nextChunk) {
@@ -1168,7 +1168,7 @@ size_t CC_collectWithRoots(
   assert(isChunkInList(stackChunk, origList));
   HM_unlinkChunk(origList, stackChunk);
   info.freedType = CC_FREED_STACK_CHUNK;
-  HM_freeChunkWithInfo(s, stackChunk, &infoc);
+  HM_freeChunkWithInfo(s, stackChunk, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
   info.freedType = CC_FREED_NORMAL_CHUNK;
   cp->stack = BOGUS_OBJPTR;
 

--- a/runtime/gc/concurrent-list.c
+++ b/runtime/gc/concurrent-list.c
@@ -217,8 +217,8 @@ void CC_appendConcList(CC_concList concList1, CC_concList concList2) {
   pthread_mutex_unlock(&concList1->mutex);
 }
 
-void CC_freeChunksInConcListWithInfo(GC_state s, CC_concList concList, void *info) {
+void CC_freeChunksInConcListWithInfo(GC_state s, CC_concList concList, void *info, enum BlockPurpose purpose) {
   struct HM_chunkList _chunkList;
   CC_popAsChunkList(concList, &(_chunkList));
-  HM_freeChunksInListWithInfo(s, &(_chunkList), info, BLOCK_FOR_UNKNOWN_PURPOSE);
+  HM_freeChunksInListWithInfo(s, &(_chunkList), info, purpose);
 }

--- a/runtime/gc/concurrent-list.c
+++ b/runtime/gc/concurrent-list.c
@@ -217,5 +217,5 @@ void CC_appendConcList(CC_concList concList1, CC_concList concList2) {
 void CC_freeChunksInConcListWithInfo(GC_state s, CC_concList concList, void *info) {
   struct HM_chunkList _chunkList;
   CC_popAsChunkList(concList, &(_chunkList));
-  HM_freeChunksInListWithInfo(s, &(_chunkList), info);
+  HM_freeChunksInListWithInfo(s, &(_chunkList), info, BLOCK_FOR_UNKNOWN_PURPOSE);
 }

--- a/runtime/gc/concurrent-list.h
+++ b/runtime/gc/concurrent-list.h
@@ -25,7 +25,7 @@ struct CC_concList {
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 void CC_initConcList(CC_concList concList);
-pointer CC_storeInConcList(CC_concList concList, void* p, size_t objSize);
+pointer CC_storeInConcListWithPurpose(CC_concList concList, void* p, size_t objSize, enum BlockPurpose purpose);
 // void CC_foreachObjInList(CC_concList concList, size_t objSize, HM_foreachObjClosure f);
 // void CC_foreachRemInConc(GC_state s, CC_concList concList, struct HM_foreachDownptrClosure* f);
 void CC_popAsChunkList(CC_concList concList, HM_chunkList chunkList);

--- a/runtime/gc/concurrent-list.h
+++ b/runtime/gc/concurrent-list.h
@@ -26,12 +26,13 @@ struct CC_concList {
 
 void CC_initConcList(CC_concList concList);
 pointer CC_storeInConcListWithPurpose(CC_concList concList, void* p, size_t objSize, enum BlockPurpose purpose);
+
 // void CC_foreachObjInList(CC_concList concList, size_t objSize, HM_foreachObjClosure f);
 // void CC_foreachRemInConc(GC_state s, CC_concList concList, struct HM_foreachDownptrClosure* f);
 void CC_popAsChunkList(CC_concList concList, HM_chunkList chunkList);
 
 HM_chunk CC_getLastChunk (CC_concList concList);
-void CC_freeChunksInConcListWithInfo(GC_state s, CC_concList concList, void *info);
+void CC_freeChunksInConcListWithInfo(GC_state s, CC_concList concList, void *info, enum BlockPurpose purpose);
 void CC_appendConcList(CC_concList concList1, CC_concList concList2);
 
 #endif /* MLTON_GC_INTERNAL_FUNCS */

--- a/runtime/gc/concurrent-stack.c
+++ b/runtime/gc/concurrent-stack.c
@@ -71,7 +71,7 @@ bool CC_stack_data_push(CC_stack_data* stack, void* datum){
     stack->storage[stack->size++] = datum;
 #endif
 
-    HM_storeInchunkList(&(stack->storage), &(datum), sizeof(datum));
+    HM_storeInChunkList(&(stack->storage), &(datum), sizeof(datum));
     pthread_mutex_unlock(&stack->mutex);
     return TRUE;
 }

--- a/runtime/gc/concurrent-stack.c
+++ b/runtime/gc/concurrent-stack.c
@@ -71,7 +71,7 @@ bool CC_stack_data_push(CC_stack_data* stack, void* datum){
     stack->storage[stack->size++] = datum;
 #endif
 
-    HM_storeInChunkList(&(stack->storage), &(datum), sizeof(datum));
+    HM_storeInChunkListWithPurpose(&(stack->storage), &(datum), sizeof(datum), BLOCK_FOR_FORGOTTEN_SET);
     pthread_mutex_unlock(&stack->mutex);
     return TRUE;
 }
@@ -141,7 +141,7 @@ void CC_stack_data_free(CC_stack_data* stack){
 #endif
 
 void CC_stack_data_free(GC_state s, CC_stack_data* stack) {
-  HM_freeChunksInList(s, &(stack->storage));
+  HM_freeChunksInListWithInfo(s, &(stack->storage), NULL, BLOCK_FOR_FORGOTTEN_SET);
 }
 
 void CC_stack_free(GC_state s, CC_stack* stack) {
@@ -154,7 +154,7 @@ void CC_stack_free(GC_state s, CC_stack* stack) {
 
 void CC_stack_data_clear(GC_state s, CC_stack_data* stack){
     pthread_mutex_lock(&stack->mutex);
-    HM_freeChunksInList(s, &(stack->storage));
+    HM_freeChunksInListWithInfo(s, &(stack->storage), NULL, BLOCK_FOR_FORGOTTEN_SET);
     pthread_mutex_unlock(&stack->mutex);
 }
 

--- a/runtime/gc/controls.h
+++ b/runtime/gc/controls.h
@@ -64,6 +64,7 @@ struct GC_controls {
   size_t allocBlocksMinSize;
   size_t superblockThreshold; // upper bound on size-class of a superblock
   size_t megablockThreshold; // upper bound on size-class of a megablock (unmap above this threshold)
+  struct timespec blockUsageSampleInterval;
   float emptinessFraction;
   bool debugKeepFreeBlocks;
   bool manageEntanglement;

--- a/runtime/gc/ebr.c
+++ b/runtime/gc/ebr.c
@@ -73,7 +73,7 @@ static void rotateAndReclaim(GC_state s, EBR_shared ebr)
     }
   }
 
-  HM_freeChunksInList(s, limboBag);
+  HM_freeChunksInListWithInfo(s, limboBag, NULL, BLOCK_FOR_EBR);
   HM_initChunkList(limboBag); // clear it out
 }
 
@@ -153,7 +153,10 @@ void EBR_retire(GC_state s, EBR_shared ebr, void *ptr)
 
   // slow path: allocate new chunk
 
-  chunk = HM_allocateChunk(limboBag, sizeof(void *));
+  chunk = HM_allocateChunkWithPurpose(
+    limboBag,
+    sizeof(void *),
+    BLOCK_FOR_EBR);
 
   assert(NULL != chunk &&
          HM_getChunkSizePastFrontier(chunk) >= sizeof(void *));

--- a/runtime/gc/entangled-ebr.c
+++ b/runtime/gc/entangled-ebr.c
@@ -6,8 +6,8 @@
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-void freeChunk (GC_state s, void *ptr) {
-  HM_freeChunk(s, (HM_chunk)ptr);
+void freeChunk(GC_state s, void *ptr) {
+  HM_freeChunkWithInfo(s, (HM_chunk)ptr, NULL, BLOCK_FOR_HEAP_CHUNK);
 }
 
 void HM_EBR_init(GC_state s) {

--- a/runtime/gc/entanglement-suspects.c
+++ b/runtime/gc/entanglement-suspects.c
@@ -58,7 +58,7 @@ void clear_suspect(
   if (pinType(header) == PIN_ANY && unpinDepth < eargs->heapDepth) {
     /* Not ready to be cleared */
     HM_HierarchicalHeap unpinHeap = HM_HH_getHeapAtDepth(s, eargs->thread, unpinDepth);
-    HM_storeInchunkList(HM_HH_getSuspects(unpinHeap), opp, sizeof(objptr));
+    HM_storeInChunkList(HM_HH_getSuspects(unpinHeap), opp, sizeof(objptr));
     return;
   }
 
@@ -69,7 +69,7 @@ void clear_suspect(
   }
   else {
     /*oops something changed in b/w, let's try at the next join*/
-    HM_storeInchunkList(eargs->newList, opp, sizeof(objptr));
+    HM_storeInChunkList(eargs->newList, opp, sizeof(objptr));
   }
 }
 
@@ -95,7 +95,7 @@ void ES_add(__attribute__((unused)) GC_state s, HM_chunkList es, objptr op)
     return;
   }
   s->cumulativeStatistics->numSuspectsMarked++;
-  HM_storeInchunkList(es, &op, sizeof(objptr));
+  HM_storeInChunkList(es, &op, sizeof(objptr));
 }
 
 int ES_foreachSuspect(

--- a/runtime/gc/entanglement-suspects.c
+++ b/runtime/gc/entanglement-suspects.c
@@ -58,7 +58,7 @@ void clear_suspect(
   if (pinType(header) == PIN_ANY && unpinDepth < eargs->heapDepth) {
     /* Not ready to be cleared */
     HM_HierarchicalHeap unpinHeap = HM_HH_getHeapAtDepth(s, eargs->thread, unpinDepth);
-    HM_storeInChunkList(HM_HH_getSuspects(unpinHeap), opp, sizeof(objptr));
+    HM_storeInChunkListWithPurpose(HM_HH_getSuspects(unpinHeap), opp, sizeof(objptr), BLOCK_FOR_SUSPECTS);
     return;
   }
 
@@ -69,7 +69,7 @@ void clear_suspect(
   }
   else {
     /*oops something changed in b/w, let's try at the next join*/
-    HM_storeInChunkList(eargs->newList, opp, sizeof(objptr));
+    HM_storeInChunkListWithPurpose(eargs->newList, opp, sizeof(objptr), BLOCK_FOR_SUSPECTS);
   }
 }
 
@@ -95,7 +95,7 @@ void ES_add(__attribute__((unused)) GC_state s, HM_chunkList es, objptr op)
     return;
   }
   s->cumulativeStatistics->numSuspectsMarked++;
-  HM_storeInChunkList(es, &op, sizeof(objptr));
+  HM_storeInChunkListWithPurpose(es, &op, sizeof(objptr), BLOCK_FOR_SUSPECTS);
 }
 
 int ES_foreachSuspect(
@@ -154,5 +154,5 @@ void ES_clear(GC_state s, HM_HierarchicalHeap hh)
   int numSuspects = ES_foreachSuspect(s, &oldList, &fObjptrClosure);
   s->cumulativeStatistics->numSuspectsCleared+=numSuspects;
 
-  HM_freeChunksInList(s, &(oldList));
+  HM_freeChunksInListWithInfo(s, &(oldList), NULL, BLOCK_FOR_SUSPECTS);
 }

--- a/runtime/gc/fixed-size-allocator.c
+++ b/runtime/gc/fixed-size-allocator.c
@@ -6,7 +6,11 @@
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize) {
+void initFixedSizeAllocator(
+  FixedSizeAllocator fsa,
+  size_t fixedSize,
+  enum BlockPurpose purpose)
+{
   size_t minSize = sizeof(struct FixedSizeElement);
   fsa->fixedSize = align(fixedSize < minSize ? minSize : fixedSize, 8);
   HM_initChunkList(&(fsa->buffer));
@@ -16,6 +20,7 @@ void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize) {
   fsa->numAllocated = 0;
   fsa->numLocalFreed = 0;
   fsa->numSharedFreed = 0;
+  fsa->purpose = purpose;
   return;
 }
 
@@ -86,7 +91,7 @@ void* allocateFixedSize(FixedSizeAllocator fsa) {
     * to their original buffer, by looking up the chunk header.
     */
 
-  chunk = HM_allocateChunk(buffer, fsa->fixedSize + sizeof(void*));
+  chunk = HM_allocateChunkWithPurpose(buffer, fsa->fixedSize + sizeof(void*), fsa->purpose);
   pointer gap = HM_shiftChunkStart(chunk, sizeof(void*));
   *(FixedSizeAllocator *)gap = fsa;
 

--- a/runtime/gc/fixed-size-allocator.h
+++ b/runtime/gc/fixed-size-allocator.h
@@ -29,6 +29,7 @@ typedef struct FixedSizeAllocator {
   size_t numAllocated;
   size_t numLocalFreed;
   size_t numSharedFreed;
+  enum BlockPurpose purpose;
 
   /** A bit of a hack. I just want quick access to pages to store elements.
     * I'll reuse the frontier mechanism inherent to chunks to remember which
@@ -66,7 +67,10 @@ typedef struct FixedSizeAllocator *FixedSizeAllocator;
 /** Initialize [fsa] to be able to allocate objects of size [fixedSize].
   * You should never re-initialize an allocator.
   */
-void initFixedSizeAllocator(FixedSizeAllocator fsa, size_t fixedSize);
+void initFixedSizeAllocator(
+  FixedSizeAllocator fsa,
+  size_t fixedSize,
+  enum BlockPurpose purpose);
 
 
 /** Allocate an object of the size specified when the allocator was initialized.

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -106,9 +106,7 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   HM_EBR_leaveQuiescentState(s);
   HM_EBR_enterQuiescentState(s);
 
-  if (s->procNumber == 0) {
-    logCurrentBlockUsage(s);
-  }
+  maybeSample(s, s->blockUsageSampler);
 
   // HM_HierarchicalHeap h = getThreadCurrent(s)->hierarchicalHeap;
   // while (h->nextAncestor != NULL) h = h->nextAncestor;

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -53,7 +53,11 @@ void growStackCurrent(GC_state s) {
 
   /* in this case, the new stack needs more space, so allocate a new chunk,
    * copy the stack, and throw away the old chunk. */
-  HM_chunk newChunk = HM_allocateChunk(HM_HH_getChunkList(newhh), stackSize);
+  HM_chunk newChunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(newhh),
+    stackSize,
+    BLOCK_FOR_HEAP_CHUNK);
+    
   if (NULL == newChunk) {
     DIE("Ran out of space to grow stack!");
   }

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -102,6 +102,10 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
   HM_EBR_leaveQuiescentState(s);
   HM_EBR_enterQuiescentState(s);
 
+  if (s->procNumber == 0) {
+    logCurrentBlockUsage(s);
+  }
+
   // HM_HierarchicalHeap h = getThreadCurrent(s)->hierarchicalHeap;
   // while (h->nextAncestor != NULL) h = h->nextAncestor;
   // if (HM_HH_getDepth(h) == 0 && HM_getChunkListSize(HM_HH_getChunkList(h)) > 8192) {

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -32,6 +32,7 @@ struct GC_state {
   volatile uint32_t atomicState;
   struct BlockAllocator *blockAllocatorGlobal;
   struct BlockAllocator *blockAllocatorLocal;
+  struct Sampler *blockUsageSampler;
   objptr callFromCHandlerThread; /* Handler for exported C calls (in heap). */
   pointer callFromCOpArgsResPtr; /* Pass op, args, and res from exported C call */
   struct GC_controls *controls;

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -664,7 +664,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
       ES_foreachSuspect(s, suspects, &fObjptrClosure);
       info.depth = depth;
       info.freedType = LGC_FREED_SUSPECT_CHUNK;
-      HM_freeChunksInListWithInfo(s, suspects, &infoc);
+      HM_freeChunksInListWithInfo(s, suspects, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
     }
   }
 
@@ -693,7 +693,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
 #endif
       info.depth = HM_HH_getDepth(hhTail);
       info.freedType = LGC_FREED_REMSET_CHUNK;
-      HM_freeChunksInListWithInfo(s, &(remset->private), &infoc);
+      HM_freeChunksInListWithInfo(s, &(remset->private), &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
     }
 
 #if ASSERT

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -717,7 +717,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
       }
       else
       {
-        HM_freeChunk(s, chunk);
+        HM_freeChunkWithInfo(s, chunk, &infoc, BLOCK_FOR_HEAP_CHUNK);
       }
       chunk = next;
     }
@@ -1931,7 +1931,11 @@ pointer copyObject(pointer p,
     /* Need to allocate a new chunk. Safe to use the dechecker state of where
      * the object came from, as all objects in the same heap can be safely
      * reassigned to any dechecker state of that heap. */
-    chunk = HM_allocateChunk(tgtChunkList, objectSize);
+    chunk = HM_allocateChunkWithPurpose(
+      tgtChunkList,
+      objectSize,
+      BLOCK_FOR_HEAP_CHUNK);
+
     if (NULL == chunk)
     {
       DIE("Ran out of space for Hierarchical Heap!");

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -693,7 +693,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
 #endif
       info.depth = HM_HH_getDepth(hhTail);
       info.freedType = LGC_FREED_REMSET_CHUNK;
-      HM_freeChunksInListWithInfo(s, &(remset->private), &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+      HM_freeChunksInListWithInfo(s, &(remset->private), &infoc, BLOCK_FOR_REMEMBERED_SET);
     }
 
 #if ASSERT
@@ -1240,7 +1240,7 @@ void copySuspect(
     return;
   }
   uint32_t opDepth = args->toDepth;
-  HM_storeInchunkList(HM_HH_getSuspects(toSpaceHH(s, args, opDepth)), &new_ptr, sizeof(objptr));
+  HM_storeInChunkList(HM_HH_getSuspects(toSpaceHH(s, args, opDepth)), &new_ptr, sizeof(objptr));
 }
 
 bool headerForwarded(GC_header h)

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -664,7 +664,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
       ES_foreachSuspect(s, suspects, &fObjptrClosure);
       info.depth = depth;
       info.freedType = LGC_FREED_SUSPECT_CHUNK;
-      HM_freeChunksInListWithInfo(s, suspects, &infoc, BLOCK_FOR_UNKNOWN_PURPOSE);
+      HM_freeChunksInListWithInfo(s, suspects, &infoc, BLOCK_FOR_SUSPECTS);
     }
   }
 
@@ -1240,7 +1240,11 @@ void copySuspect(
     return;
   }
   uint32_t opDepth = args->toDepth;
-  HM_storeInChunkList(HM_HH_getSuspects(toSpaceHH(s, args, opDepth)), &new_ptr, sizeof(objptr));
+  HM_storeInChunkListWithPurpose(
+    HM_HH_getSuspects(toSpaceHH(s, args, opDepth)),
+    &new_ptr,
+    sizeof(objptr),
+    BLOCK_FOR_SUSPECTS);
 }
 
 bool headerForwarded(GC_header h)

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -588,7 +588,10 @@ bool HM_HH_extend(GC_state s, GC_thread thread, size_t bytesRequested)
     hh = newhh;
   }
 
-  chunk = HM_allocateChunk(HM_HH_getChunkList(hh), bytesRequested);
+  chunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(hh),
+    bytesRequested,
+    BLOCK_FOR_HEAP_CHUNK);
 
   if (NULL == chunk) {
     return FALSE;
@@ -690,8 +693,11 @@ void splitHeapForCC(GC_state s, GC_thread thread) {
 
   HM_HierarchicalHeap newHH = HM_HH_new(s, HM_HH_getDepth(hh));
   thread->hierarchicalHeap = newHH;
-  HM_chunk chunk =
-    HM_allocateChunk(HM_HH_getChunkList(newHH), GC_HEAP_LIMIT_SLOP);
+  HM_chunk chunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(newHH),
+    GC_HEAP_LIMIT_SLOP,
+    BLOCK_FOR_HEAP_CHUNK);
+    
   chunk->levelHead = HM_HH_getUFNode(newHH);
 
 #ifdef DETECT_ENTANGLEMENT
@@ -874,7 +880,11 @@ objptr copyCurrentStack(GC_state s, GC_thread thread) {
   assert(isStackReservedAligned(s, reserved));
   size_t stackSize = sizeofStackWithMetaData(s, reserved);
 
-  HM_chunk newChunk = HM_allocateChunk(HM_HH_getChunkList(hh), stackSize);
+  HM_chunk newChunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(hh),
+    stackSize,
+    BLOCK_FOR_HEAP_CHUNK);
+
   if (NULL == newChunk) {
     DIE("Ran out of space to copy stack!");
   }

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -608,13 +608,7 @@ void GC_lateInit(GC_state s) {
   HM_EBR_init(s);
 
   initLocalBlockAllocator(s, initGlobalBlockAllocator(s));
-
-  struct timespec now;
-  timespec_now(&now);
-  LOG(LM_BLOCK_ALLOCATOR, LL_INFO,
-    "block-allocator(%zu.%.9zu): init",
-    now.tv_sec,
-    now.tv_nsec);
+  s->blockUsageSampler = newBlockUsageSampler(s);
 
   s->nextChunkAllocSize = s->controls->allocChunkSize;
 
@@ -648,6 +642,7 @@ void GC_duplicate (GC_state d, GC_state s) {
   d->wsQueueTop = BOGUS_OBJPTR;
   d->wsQueueBot = BOGUS_OBJPTR;
   initLocalBlockAllocator(d, s->blockAllocatorGlobal);
+  d->blockUsageSampler = s->blockUsageSampler;
   initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap), BLOCK_FOR_HH_ALLOCATOR);
   initFixedSizeAllocator(getUFAllocator(d), sizeof(struct HM_UnionFindNode), BLOCK_FOR_UF_ALLOCATOR);
   d->hhEBR = s->hhEBR;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -509,8 +509,8 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->rootsLength = 0;
   s->savedThread = BOGUS_OBJPTR;
 
-  initFixedSizeAllocator(getHHAllocator(s), sizeof(struct HM_HierarchicalHeap));
-  initFixedSizeAllocator(getUFAllocator(s), sizeof(struct HM_UnionFindNode));
+  initFixedSizeAllocator(getHHAllocator(s), sizeof(struct HM_HierarchicalHeap), BLOCK_FOR_HH_ALLOCATOR);
+  initFixedSizeAllocator(getUFAllocator(s), sizeof(struct HM_UnionFindNode), BLOCK_FOR_UF_ALLOCATOR);
   s->numberDisentanglementChecks = 0;
 
   s->signalHandlerThread = BOGUS_OBJPTR;
@@ -648,8 +648,8 @@ void GC_duplicate (GC_state d, GC_state s) {
   d->wsQueueTop = BOGUS_OBJPTR;
   d->wsQueueBot = BOGUS_OBJPTR;
   initLocalBlockAllocator(d, s->blockAllocatorGlobal);
-  initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap));
-  initFixedSizeAllocator(getUFAllocator(d), sizeof(struct HM_UnionFindNode));
+  initFixedSizeAllocator(getHHAllocator(d), sizeof(struct HM_HierarchicalHeap), BLOCK_FOR_HH_ALLOCATOR);
+  initFixedSizeAllocator(getUFAllocator(d), sizeof(struct HM_UnionFindNode), BLOCK_FOR_UF_ALLOCATOR);
   d->hhEBR = s->hhEBR;
   d->hmEBR = s->hmEBR;
   d->nextChunkAllocSize = s->nextChunkAllocSize;

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -609,6 +609,13 @@ void GC_lateInit(GC_state s) {
 
   initLocalBlockAllocator(s, initGlobalBlockAllocator(s));
 
+  struct timespec now;
+  timespec_now(&now);
+  LOG(LM_BLOCK_ALLOCATOR, LL_INFO,
+    "block-allocator(%zu.%.9zu): init",
+    now.tv_sec,
+    now.tv_nsec);
+
   s->nextChunkAllocSize = s->controls->allocChunkSize;
 
   /* Initialize profiling.  This must occur after processing

--- a/runtime/gc/logger.c
+++ b/runtime/gc/logger.c
@@ -205,6 +205,7 @@ bool stringToLogModule(enum LogModule* module, const char* moduleString) {
 
   struct Conversion conversions[] =
       {{.string = "allocation", .module = LM_ALLOCATION},
+       {.string = "block-allocator", .module = LM_BLOCK_ALLOCATOR},
        {.string = "chunk", .module = LM_CHUNK},
        {.string = "chunk-pool", .module = LM_CHUNK_POOL},
        {.string = "dfs-mark", .module = LM_DFS_MARK},

--- a/runtime/gc/logger.h
+++ b/runtime/gc/logger.h
@@ -18,6 +18,7 @@
 
 enum LogModule {
   LM_ALLOCATION,
+  LM_BLOCK_ALLOCATOR,
   LM_CHUNK,
   LM_CHUNK_POOL,
   LM_DFS_MARK,

--- a/runtime/gc/new-object.c
+++ b/runtime/gc/new-object.c
@@ -147,8 +147,16 @@ GC_thread newThreadWithHeap(
    * yet. */
   HM_HierarchicalHeap hh = HM_HH_new(s, depth);
 
-  HM_chunk tChunk = HM_allocateChunk(HM_HH_getChunkList(hh), threadSize);
-  HM_chunk sChunk = HM_allocateChunk(HM_HH_getChunkList(hh), stackSize);
+  HM_chunk tChunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(hh),
+    threadSize,
+    BLOCK_FOR_HEAP_CHUNK);
+    
+  HM_chunk sChunk = HM_allocateChunkWithPurpose(
+    HM_HH_getChunkList(hh),
+    stackSize,
+    BLOCK_FOR_HEAP_CHUNK);
+    
   if (NULL == sChunk || NULL == tChunk) {
     DIE("Ran out of space for thread+stack allocation!");
   }

--- a/runtime/gc/remembered-set.c
+++ b/runtime/gc/remembered-set.c
@@ -189,6 +189,6 @@ void HM_appendRemSet(HM_remSet r1, HM_remSet r2) {
 }
 
 void HM_freeRemSetWithInfo(GC_state s, HM_remSet remSet, void* info) {
-  HM_freeChunksInListWithInfo(s, &(remSet->private), info, BLOCK_FOR_UNKNOWN_PURPOSE);
-  CC_freeChunksInConcListWithInfo(s, &(remSet->public), info);
+  HM_freeChunksInListWithInfo(s, &(remSet->private), info, BLOCK_FOR_REMEMBERED_SET);
+  CC_freeChunksInConcListWithInfo(s, &(remSet->public), info, BLOCK_FOR_REMEMBERED_SET);
 }

--- a/runtime/gc/remembered-set.c
+++ b/runtime/gc/remembered-set.c
@@ -11,10 +11,10 @@ void HM_initRemSet(HM_remSet remSet) {
 
 void HM_remember(HM_remSet remSet, HM_remembered remElem, bool conc) {
   if (!conc) {
-    HM_storeInchunkList(&(remSet->private), (void*)remElem, sizeof(struct HM_remembered));
+    HM_storeInChunkListWithPurpose(&(remSet->private), (void*)remElem, sizeof(struct HM_remembered), BLOCK_FOR_REMEMBERED_SET);
   }
   else {
-    CC_storeInConcList(&(remSet->public), (void *)remElem, sizeof(struct HM_remembered));
+    CC_storeInConcListWithPurpose(&(remSet->public), (void *)remElem, sizeof(struct HM_remembered), BLOCK_FOR_REMEMBERED_SET);
   }
 }
 

--- a/runtime/gc/remembered-set.c
+++ b/runtime/gc/remembered-set.c
@@ -189,6 +189,6 @@ void HM_appendRemSet(HM_remSet r1, HM_remSet r2) {
 }
 
 void HM_freeRemSetWithInfo(GC_state s, HM_remSet remSet, void* info) {
-  HM_freeChunksInListWithInfo(s, &(remSet->private), info);
+  HM_freeChunksInListWithInfo(s, &(remSet->private), info, BLOCK_FOR_UNKNOWN_PURPOSE);
   CC_freeChunksInConcListWithInfo(s, &(remSet->public), info);
 }

--- a/runtime/gc/sampler.c
+++ b/runtime/gc/sampler.c
@@ -1,0 +1,63 @@
+/* Copyright (C) 2022 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+
+void initSampler(
+  __attribute__((unused)) GC_state s,
+  Sampler samp,
+  SamplerClosure func,
+  struct timespec *desiredInterval)
+{
+  samp->func = *func;
+  samp->desiredInterval = *desiredInterval;
+  samp->currentEpoch = 0;
+  timespec_now(&(samp->absoluteStart));
+}
+
+
+static void timespec_mul(struct timespec *dst, size_t multiplier) {
+  size_t sec = dst->tv_sec;
+  size_t nsec = dst->tv_nsec;
+
+  size_t nps = 1000L * 1000 * 1000;
+
+  size_t new_nsec = (nsec * multiplier) % nps;
+  size_t add_sec = (nsec * multiplier) / nps;
+
+  dst->tv_sec = (sec * multiplier) + add_sec;
+  dst->tv_nsec = new_nsec;
+}
+
+
+static inline double timespec_to_seconds(struct timespec *tm) {
+  return (double)tm->tv_sec + ((double)tm->tv_nsec * 0.000000001);
+}
+
+
+void maybeSample(GC_state s, Sampler samp) {
+  size_t oldEpoch = samp->currentEpoch;
+
+  // compute the time of the last successful sample (relative to start)
+  struct timespec lastSample;
+  lastSample = samp->desiredInterval;
+  timespec_mul(&lastSample, oldEpoch);
+
+  // compare against current time by computing epoch diff
+  struct timespec now;
+  timespec_now(&now);
+  timespec_sub(&now, &(samp->absoluteStart));
+  double diff = timespec_to_seconds(&now) - timespec_to_seconds(&lastSample);
+  long epochDiff = (long)(diff / timespec_to_seconds(&samp->desiredInterval));
+
+  if (epochDiff < 1)
+    return;
+
+  size_t newEpoch = oldEpoch + epochDiff;
+
+  if (__sync_bool_compare_and_swap(&samp->currentEpoch, oldEpoch, newEpoch)) {
+    samp->func.fun(s, &now, samp->func.env);
+  }
+}

--- a/runtime/gc/sampler.h
+++ b/runtime/gc/sampler.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2022 Sam Westrick
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#ifndef SAMPLER_H_
+#define SAMPLER_H_
+
+#if (defined (MLTON_GC_INTERNAL_FUNCS))
+
+typedef void (*SamplerFun) (GC_state s, struct timespec *tm, void *env);
+
+typedef struct SamplerClosure {
+  SamplerFun fun;
+  void *env;
+} *SamplerClosure;
+
+typedef struct Sampler {
+  struct SamplerClosure func;
+  struct timespec desiredInterval;
+  struct timespec absoluteStart;
+  size_t currentEpoch;
+} * Sampler;
+
+
+void initSampler(GC_state s, Sampler samp, SamplerClosure func, struct timespec *desiredInterval);
+
+void maybeSample(GC_state s, Sampler samp);
+
+#endif /* MLTON_GC_INTERNAL_FUNCS */
+
+
+#endif /* SAMPLER_H_ */


### PR DESCRIPTION
Tracking global block usage statistics in the block allocator, by assigning a purpose to each block and keeping track of how many blocks have been allocated/freed for that purpose.

```C
enum BlockPurpose {
  BLOCK_FOR_HEAP_CHUNK,
  BLOCK_FOR_REMEMBERED_SET,
  BLOCK_FOR_FORGOTTEN_SET,
  BLOCK_FOR_HH_ALLOCATOR,
  BLOCK_FOR_UF_ALLOCATOR,
  BLOCK_FOR_GC_WORKLIST,
  BLOCK_FOR_UNKNOWN_PURPOSE,
  ...
}
```

## Command-line args
To see block usage statistics at runtime, you can do this:
```
$ <program> @mpl procs <N> log-level block-allocator:info -- <args>
```

The default is to sample every 1 second and log the output. To control the sample rate, use the `block-usage-sample-interval` parameter:
```
$ <program> @mpl procs <N> log-level block-allocator:info block-usage-sample-interval <T> -- <args>
```
Here, we pass a time `T`, which has a time unit suffix: `s` for seconds, `m` for milliseconds, `u` for microseconds, and `n` for nanoseconds. For example, `150m` will sample every 150 milliseconds, `2500u` will sample every 2500 microseconds, etc.

**Logging control**. This mechanism currently reuses the existing logger. Note that it can be helpful to use `@mpl log-file <FILENAME> --` to output to a file rather than interleaving log messages with normal output.

## Example and output description

Example output with `log-level block-allocator:info block-usage-sample-interval 200m` which samples every 200 milliseconds:

```
INFO   [P07|logCurrentBlockUsage]: block-allocator(7.200003685)
  currently mapped           167794 (= 167794 - 0)
  BLOCK_FOR_HEAP_CHUNK       111422 (66%) (= 501652 - 390230)
  BLOCK_FOR_REMEMBERED_SET   590 (0%) (= 32146 - 31556)
  BLOCK_FOR_FORGOTTEN_SET    0 (0%) (= 29892 - 29892)
  BLOCK_FOR_HH_ALLOCATOR     352 (0%) (= 352 - 0)
  BLOCK_FOR_UF_ALLOCATOR     44 (0%) (= 44 - 0)
  BLOCK_FOR_GC_WORKLIST      0 (0%) (= 458 - 458)
  BLOCK_FOR_UNKNOWN_PURPOSE  7 (0%) (= 7601 - 7594)
```

**Timestamp**. The log message begins with `block-allocator(T)` where `T` is the elapsed time (in seconds) since the beginning of the program. In this example, 7.2 seconds have elapsed so far.

**Current num blocks mapped**. The second line shows how many blocks are currently mapped from the OS; this number increases and decreases as blocks are mapped and unmapped. The format is `<num currently mapped> (= <cumulative mapped> - <cumulative unmapped>)`; when blocks are released back to the OS, this will be shown in the cumulative unmapped count.

**Blocks allocated/freed**. The remaining lines each have the form:
```<purpose> <count> <percent of currently mapped> (= <cumulative allocated> - <cumulative freed>)```
For example, in the above log, there are currently ~111K blocks in use for heap chunks, which is 66% of all blocks currently mapped from the OS; cumulatively, the program has allocated ~502K blocks for heap chunks and has freed 390K of those.

## Other notes

This PR includes a general-purpose "sampler" mechanism which allows for running an arbitrary function periodically. It was very helpful for sampling block usage statistics, and seems really nice in general. I think we could start using it for other purposes.

The implementation strategy is ~lock-free~ *wait-free*, and relies on hijacking failed limit checks (to enter the runtime system).

See `runtime/gc/sampler.{c,h}` for more info.