### PR TITLE
Improve performance of entangled read barriers

### DIFF
--- a/runtime/gc/assign.c
+++ b/runtime/gc/assign.c
@@ -21,14 +21,14 @@ objptr Assignable_decheckObjptr(objptr dst, objptr src)
     return src;
   }
 
-  HM_EBR_leaveQuiescentState(s);
+  // HM_EBR_leaveQuiescentState(s);
   if (!decheck(s, src))
   {
     assert (isMutable(s, dstp));
     new_src = manage_entangled(s, src, getThreadCurrent(s)->decheckState);
     assert (isPinned(new_src));
   }
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
   assert (!hasFwdPtr(objptrToPointer(new_src, NULL)));
   return new_src;
 }
@@ -48,7 +48,7 @@ objptr Assignable_readBarrier(
   {
     return ptr;
   }
-  HM_EBR_leaveQuiescentState(s);
+  // HM_EBR_leaveQuiescentState(s);
   if (!decheck(s, ptr))
   {
     assert (ES_contains(NULL, obj));
@@ -64,7 +64,7 @@ objptr Assignable_readBarrier(
     // }
     ptr = manage_entangled(s, ptr, getThreadCurrent(s)->decheckState);
   }
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
   assert (!hasFwdPtr(objptrToPointer(ptr, NULL)));
 
   return ptr;

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -104,7 +104,7 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
 
   // ebr for chunks
   HM_EBR_leaveQuiescentState(s);
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
 
   maybeSample(s, s->blockUsageSampler);
 

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -730,7 +730,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
   }
 
   HM_EBR_leaveQuiescentState(s);
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
 
   /* after everything has been scavenged, we have to move the pinned chunks */
   depth = thread->currentDepth + 1;


### PR DESCRIPTION
Switch to assuming non-quiescent for HM_EBR (management/retirement of entangled chunks) in the common case.

This allows for the read barrier to not perform any quiescence maintenance, skipping that overhead entirely.

This appears to be very important for certain benchmarks, and may have been contributing to part of our performance dip problem. For example, the entangled `linden-pq` benchmark no longer experiences perf dip near 50 procs, and is now over 2x faster on 72 procs.

Performance of disentangled benchmarks appears mostly unaffected by this patch.

(Some follow-up thoughts: perhaps we should revisit the EBR implementation, especially `rotateAndReclaim` which introduces an unknown delay. The actual work of iterating through the limbo bag and freeing individual elements could be parallelized and spread across the span, rather than scheduling it immediately onto the current processor, as it is done now...)