### PR TITLE
Clear candidates (suspects) in parallel: entanglement management perf improvement (and other fixes)

### DIFF
--- a/basis-library/mlton/thread.sig
+++ b/basis-library/mlton/thread.sig
@@ -42,6 +42,8 @@ signature MLTON_THREAD =
       structure HierarchicalHeap :
         sig
           type thread = Basic.t
+          type clear_set
+          type finished_clear_set_grain
 
           (* The level (depth) of a thread's heap in the hierarchy. *)
           val getDepth : thread -> int
@@ -70,6 +72,12 @@ signature MLTON_THREAD =
           val promoteChunks : thread -> unit
 
           val clearSuspectsAtDepth: thread * int -> unit
+          val numSuspectsAtDepth: thread * int -> int
+          val takeClearSetAtDepth: thread * int -> clear_set
+          val numChunksInClearSet: clear_set -> int
+          val processClearSetGrain: clear_set * int * int -> finished_clear_set_grain
+          val commitFinishedClearSetGrain: thread * finished_clear_set_grain -> unit
+          val deleteClearSet: clear_set -> unit
 
           (* "put a new thread in the hierarchy *)
           val moveNewThreadToDepth : thread * int -> unit

--- a/basis-library/mlton/thread.sig
+++ b/basis-library/mlton/thread.sig
@@ -69,6 +69,8 @@ signature MLTON_THREAD =
           (* Move all chunks at the current depth up one level. *)
           val promoteChunks : thread -> unit
 
+          val clearSuspectsAtDepth: thread * int -> unit
+
           (* "put a new thread in the hierarchy *)
           val moveNewThreadToDepth : thread * int -> unit
 

--- a/basis-library/mlton/thread.sml
+++ b/basis-library/mlton/thread.sml
@@ -90,6 +90,9 @@ struct
     Prim.moveNewThreadToDepth (t, Word32.fromInt d)
   fun checkFinishedCCReadyToJoin () =
     Prim.checkFinishedCCReadyToJoin (gcState ())
+
+  fun clearSuspectsAtDepth (t, d) =
+    Prim.clearSuspectsAtDepth (gcState (), t, Word32.fromInt d)
 end
 
 structure Disentanglement =

--- a/basis-library/mlton/thread.sml
+++ b/basis-library/mlton/thread.sml
@@ -73,6 +73,9 @@ struct
   type thread = Basic.t
   type t = MLtonPointer.t
 
+  type clear_set = MLtonPointer.t
+  type finished_clear_set_grain = MLtonPointer.t
+
   fun forceLeftHeap (myId, t) = Prim.forceLeftHeap(Word32.fromInt myId, t)
   fun forceNewChunk () = Prim.forceNewChunk (gcState ())
   fun registerCont (kl, kr, k, t) = Prim.registerCont(kl, kr, k, t)
@@ -93,6 +96,24 @@ struct
 
   fun clearSuspectsAtDepth (t, d) =
     Prim.clearSuspectsAtDepth (gcState (), t, Word32.fromInt d)
+  
+  fun numSuspectsAtDepth (t, d) =
+    Word64.toInt (Prim.numSuspectsAtDepth (gcState (), t, Word32.fromInt d))
+
+  fun takeClearSetAtDepth (t, d) =
+    Prim.takeClearSetAtDepth (gcState (), t, Word32.fromInt d)
+
+  fun numChunksInClearSet c =
+    Word64.toInt (Prim.numChunksInClearSet (gcState (), c))
+
+  fun processClearSetGrain (c, start, stop) =
+    Prim.processClearSetGrain (gcState (), c, Word64.fromInt start, Word64.fromInt stop)
+
+  fun commitFinishedClearSetGrain (t, fcsg) =
+    Prim.commitFinishedClearSetGrain (gcState (), t, fcsg)
+
+  fun deleteClearSet c =
+    Prim.deleteClearSet (gcState (), c)
 end
 
 structure Disentanglement =

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -370,6 +370,8 @@ structure Thread =
       val setMinLocalCollectionDepth = _import "GC_HH_setMinLocalCollectionDepth" runtime private: thread * Word32.word -> unit;
       val mergeThreads = _import "GC_HH_mergeThreads" runtime private: thread * thread -> unit;
       val promoteChunks = _import "GC_HH_promoteChunks" runtime private: thread -> unit;
+      val clearSuspectsAtDepth = _import "GC_HH_clearSuspectsAtDepth" runtime private: 
+        GCState.t * thread * Word32.word -> unit;
 
       val decheckFork = _import "GC_HH_decheckFork" runtime private:
         GCState.t * Word64.word ref * Word64.word ref -> unit;

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -372,6 +372,18 @@ structure Thread =
       val promoteChunks = _import "GC_HH_promoteChunks" runtime private: thread -> unit;
       val clearSuspectsAtDepth = _import "GC_HH_clearSuspectsAtDepth" runtime private: 
         GCState.t * thread * Word32.word -> unit;
+      val numSuspectsAtDepth = _import "GC_HH_numSuspectsAtDepth" runtime private:
+        GCState.t * thread * Word32.word -> Word64.word;
+      val takeClearSetAtDepth = _import "GC_HH_takeClearSetAtDepth" runtime private:
+        GCState.t * thread * Word32.word -> Pointer.t;
+      val numChunksInClearSet = _import "GC_HH_numChunksInClearSet" runtime private:
+        GCState.t * Pointer.t -> Word64.word;
+      val processClearSetGrain = _import "GC_HH_processClearSetGrain" runtime private:
+        GCState.t * Pointer.t * Word64.word * Word64.word -> Pointer.t;
+      val commitFinishedClearSetGrain = _import "GC_HH_commitFinishedClearSetGrain" runtime private:
+        GCState.t * thread * Pointer.t -> unit;
+      val deleteClearSet = _import "GC_HH_deleteClearSet" runtime private:
+        GCState.t * Pointer.t -> unit;
 
       val decheckFork = _import "GC_HH_decheckFork" runtime private:
         GCState.t * Word64.word ref * Word64.word ref -> unit;

--- a/basis-library/schedulers/shh/Scheduler.sml
+++ b/basis-library/schedulers/shh/Scheduler.sml
@@ -336,7 +336,8 @@ struct
 
         val gr =
           if popDiscard () then
-            ( HH.promoteChunks thread
+            ( HH.clearSuspectsAtDepth (thread, depth)
+            ; HH.promoteChunks thread
             ; HH.setDepth (thread, depth)
             ; DE.decheckJoin (tidLeft, tidRight)
             (* ; dbgmsg' (fn _ => "join fast at depth " ^ Int.toString depth) *)
@@ -358,6 +359,7 @@ struct
                     val tidRight = DE.decheckGetTid t
                   in
                     HH.mergeThreads (thread, t);
+                    HH.clearSuspectsAtDepth (thread, depth);
                     HH.promoteChunks thread;
                     HH.setDepth (thread, depth);
                     DE.decheckJoin (tidLeft, tidRight);
@@ -414,6 +416,7 @@ struct
                 ; setQueueDepth (myWorkerId ()) depth
                 )
 
+            val _ = HH.clearSuspectsAtDepth (thread, depth)
             val _ = HH.promoteChunks thread
             val _ = HH.setDepth (thread, depth)
             (* val _ = dbgmsg' (fn _ => "join CC at depth " ^ Int.toString depth) *)

--- a/runtime/gc/assign.c
+++ b/runtime/gc/assign.c
@@ -21,14 +21,14 @@ objptr Assignable_decheckObjptr(objptr dst, objptr src)
     return src;
   }
 
-  HM_EBR_leaveQuiescentState(s);
+  // HM_EBR_leaveQuiescentState(s);
   if (!decheck(s, src))
   {
     assert (isMutable(s, dstp));
     new_src = manage_entangled(s, src, getThreadCurrent(s)->decheckState);
     assert (isPinned(new_src));
   }
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
   assert (!hasFwdPtr(objptrToPointer(new_src, NULL)));
   return new_src;
 }
@@ -48,7 +48,7 @@ objptr Assignable_readBarrier(
   {
     return ptr;
   }
-  HM_EBR_leaveQuiescentState(s);
+  // HM_EBR_leaveQuiescentState(s);
   if (!decheck(s, ptr))
   {
     assert (ES_contains(NULL, obj));
@@ -64,7 +64,7 @@ objptr Assignable_readBarrier(
     // }
     ptr = manage_entangled(s, ptr, getThreadCurrent(s)->decheckState);
   }
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
   assert (!hasFwdPtr(objptrToPointer(ptr, NULL)));
 
   return ptr;

--- a/runtime/gc/decheck.c
+++ b/runtime/gc/decheck.c
@@ -319,7 +319,7 @@ bool decheckIsOrdered(GC_thread thread, decheck_tid_t t1) {
 
 #ifdef DETECT_ENTANGLEMENT
 
-#ifdef ASSERT
+#if ASSERT
 void traverseAndCheck(
   GC_state s,
   __attribute__((unused)) objptr *opp,
@@ -340,14 +340,12 @@ void traverseAndCheck(
   }
 }
 #else
-void traverseAndCheck(
-    GC_state s,
+void inline traverseAndCheck(
+    __attribute__((unused)) GC_state s,
     __attribute__((unused)) objptr *opp,
-    objptr op,
+    __attribute__((unused)) objptr op,
     __attribute__((unused)) void *rawArgs)
 {
-  (void)s;
-  (void)op;
   return;
 }
 #endif

--- a/runtime/gc/decheck.h
+++ b/runtime/gc/decheck.h
@@ -53,11 +53,7 @@ bool decheckIsOrdered(GC_thread thread, decheck_tid_t t1);
 int lcaHeapDepth(decheck_tid_t t1, decheck_tid_t t2);
 bool disentangleObject(GC_state s, objptr op, uint32_t opDepth);
 objptr manage_entangled(GC_state s, objptr ptr, decheck_tid_t reader);
-void traverseAndCheck(
-    GC_state s,
-    __attribute__((unused)) objptr *opp,
-    objptr op,
-    __attribute__((unused)) void *rawArgs);
+void traverseAndCheck(GC_state s, objptr *opp ,objptr op, void *rawArgs);
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */
 
 #endif /* _DECHECK_H_ */

--- a/runtime/gc/entanglement-suspects.c
+++ b/runtime/gc/entanglement-suspects.c
@@ -59,17 +59,20 @@ void clear_suspect(
     /* Not ready to be cleared */
     HM_HierarchicalHeap unpinHeap = HM_HH_getHeapAtDepth(s, eargs->thread, unpinDepth);
     HM_storeInChunkListWithPurpose(HM_HH_getSuspects(unpinHeap), opp, sizeof(objptr), BLOCK_FOR_SUSPECTS);
+    eargs->numMoved++;
     return;
   }
 
   GC_header newHeader = header & ~(SUSPECT_MASK);
   if (__sync_bool_compare_and_swap(getHeaderp(p), header, newHeader)) {
     /* clearing successful */
+    eargs->numCleared++;
     return;
   }
   else {
     /*oops something changed in b/w, let's try at the next join*/
     HM_storeInChunkListWithPurpose(eargs->newList, opp, sizeof(objptr), BLOCK_FOR_SUSPECTS);
+    eargs->numFailed++;
   }
 }
 
@@ -159,7 +162,10 @@ void ES_clear(GC_state s, HM_HierarchicalHeap hh)
   struct ES_clearArgs eargs = {
     .newList = HM_HH_getSuspects(hh),
     .heapDepth = heapDepth,
-    .thread = getThreadCurrent(s)
+    .thread = getThreadCurrent(s),
+    .numMoved = 0,
+    .numCleared = 0,
+    .numFailed = 0
   };
   
   struct GC_foreachObjptrClosure fObjptrClosure =
@@ -170,15 +176,174 @@ void ES_clear(GC_state s, HM_HierarchicalHeap hh)
 
   HM_freeChunksInListWithInfo(s, &(oldList), NULL, BLOCK_FOR_SUSPECTS);
 
+  if (eargs.numFailed > 0) {
+    LOG(LM_HIERARCHICAL_HEAP, LL_FORCE,
+      "WARNING: %zu failed suspect clears",
+      eargs.numFailed);
+  }
+
   if (numSuspects >= SUSPECTS_THRESHOLD) {
     timespec_now(&stopTime);
     timespec_sub(&stopTime, &startTime);
     LOG(LM_HIERARCHICAL_HEAP, LL_FORCE,
-      "time to clear %zu suspects at depth %u: %d.%09d",
+      "time to process %zu suspects (%zu cleared, %zu moved) at depth %u: %ld.%09ld",
       numSuspects,
+      eargs.numCleared,
+      eargs.numMoved,
       HM_HH_getDepth(hh),
-      stopTime.tv_sec,
+      (long)stopTime.tv_sec,
       stopTime.tv_nsec
     );
   }
+}
+
+
+size_t ES_numSuspects(
+  __attribute__((unused)) GC_state s,
+  HM_HierarchicalHeap hh)
+{
+  return HM_getChunkListUsedSize(HM_HH_getSuspects(hh)) / sizeof(objptr);
+}
+
+
+ES_clearSet ES_takeClearSet(
+  __attribute__((unused)) GC_state s,
+  HM_HierarchicalHeap hh)
+{
+  ES_clearSet result = malloc(sizeof(struct ES_clearSet));
+  HM_chunkList es = HM_HH_getSuspects(hh);
+  struct HM_chunkList oldList = *es;
+  HM_initChunkList(es);
+
+  size_t numChunks = 0;
+  for (HM_chunk cursor = HM_getChunkListFirstChunk(&oldList);
+       cursor != NULL;
+       cursor = cursor->nextChunk)
+  {
+    numChunks++;
+  }
+
+  HM_chunk *chunkArray = malloc(numChunks * sizeof(HM_chunk));
+  result->chunkArray = chunkArray;
+  result->lenChunkArray = numChunks;
+  result->depth = HM_HH_getDepth(hh);
+
+  size_t i = 0;
+  for (HM_chunk cursor = HM_getChunkListFirstChunk(&oldList);
+       cursor != NULL;
+       cursor = cursor->nextChunk)
+  {
+    chunkArray[i] = cursor;
+    i++;
+  }
+
+  return result;
+}
+
+
+size_t ES_numChunksInClearSet(
+  __attribute__((unused)) GC_state s,
+  ES_clearSet es)
+{
+  return es->lenChunkArray;
+}
+
+
+void clear_suspect_par_safe(
+  __attribute__((unused)) GC_state s,
+  objptr *opp,
+  objptr op,
+  struct HM_chunkList *output,
+  size_t lenOutput)
+{
+  pointer p = objptrToPointer(op, NULL);
+  GC_header header = getHeader(p);
+  uint32_t unpinDepth = (header & UNPIN_DEPTH_MASK) >> UNPIN_DEPTH_SHIFT;
+
+  // Note: lenOutput == depth of heap whose suspects we are clearing
+  if (pinType(header) == PIN_ANY && unpinDepth < lenOutput) {
+    /* Not ready to be cleared; move it instead */
+    HM_storeInChunkListWithPurpose(&(output[unpinDepth]), opp, sizeof(objptr), BLOCK_FOR_SUSPECTS);
+    return;
+  }
+
+  GC_header newHeader = header & ~(SUSPECT_MASK);
+  if (__sync_bool_compare_and_swap(getHeaderp(p), header, newHeader)) {
+    /* clearing successful */
+    return;
+  }
+  else {
+    // oops, something changed in between
+    // Is this possible?
+    //   - Seems like it could be, if there is a CGC happening
+    //   simultaneously at the same level (and it's marking/unmarking objects)?
+    //   - If this is the only possibility, then we should be able to just
+    //   do the CAS with newHeader in a loop?
+    DIE("TODO: is this possible?");
+  }
+}
+
+
+ES_finishedClearSetGrain ES_processClearSetGrain(
+  GC_state s,
+  ES_clearSet es,
+  size_t start,
+  size_t stop)
+{
+  ES_finishedClearSetGrain result = malloc(sizeof(struct ES_finishedClearSetGrain));
+  struct HM_chunkList *output = malloc(es->depth * sizeof(struct HM_chunkList));
+  result->output = output;
+  result->lenOutput = es->depth;
+  
+  // initialize output
+  for (uint32_t i = 0; i < es->depth; i++) {
+    HM_initChunkList(&(output[i]));
+  }
+
+  // process each input chunk
+  for (size_t i = start; i < stop; i++) {
+    HM_chunk chunk = es->chunkArray[i];
+    pointer p = HM_getChunkStart(chunk);
+    pointer frontier = HM_getChunkFrontier(chunk);
+    while (p < frontier)
+    {
+      objptr* opp = (objptr*)p;
+      objptr op = *opp;
+      if (isObjptr(op)) {
+        clear_suspect_par_safe(s, opp, op, output, es->depth);
+      }
+      p += sizeof(objptr);
+    }
+  }
+
+  return result;
+}
+
+
+void ES_commitFinishedClearSetGrain(
+  GC_state s,
+  GC_thread thread,
+  ES_finishedClearSetGrain es)
+{
+  for (size_t i = 0; i < es->lenOutput; i++) {
+    HM_chunkList list = &(es->output[i]);
+    if (HM_getChunkListSize(list) == 0)
+      continue;
+
+    HM_HierarchicalHeap dest = HM_HH_getHeapAtDepth(s, thread, i);
+    HM_appendChunkList(HM_HH_getSuspects(dest), list);
+    HM_initChunkList(list);
+  }
+
+  free(es->output);
+  free(es);
+}
+
+
+void ES_deleteClearSet(GC_state s, ES_clearSet es) {
+  for (size_t i = 0; i < es->lenChunkArray; i++) {
+    HM_freeChunkWithInfo(s, es->chunkArray[i], NULL, BLOCK_FOR_SUSPECTS);
+  }
+  free(es->chunkArray);
+  free(es);
 }

--- a/runtime/gc/entanglement-suspects.h
+++ b/runtime/gc/entanglement-suspects.h
@@ -20,6 +20,8 @@ typedef struct ES_clearSet {
   HM_chunk *chunkArray; // array of chunks that need to be processed
   size_t lenChunkArray; // len(chunkArray)
   uint32_t depth;
+  size_t numSuspects;
+  struct timespec startTime;
 } * ES_clearSet;
 
 typedef struct ES_finishedClearSetGrain {

--- a/runtime/gc/entanglement-suspects.h
+++ b/runtime/gc/entanglement-suspects.h
@@ -10,7 +10,23 @@ typedef struct ES_clearArgs {
   HM_chunkList newList;
   uint32_t heapDepth;
   GC_thread thread;
+  size_t numMoved;
+  size_t numFailed;
+  size_t numCleared;
 } * ES_clearArgs;
+
+
+typedef struct ES_clearSet {
+  HM_chunk *chunkArray; // array of chunks that need to be processed
+  size_t lenChunkArray; // len(chunkArray)
+  uint32_t depth;
+} * ES_clearSet;
+
+typedef struct ES_finishedClearSetGrain {
+  struct HM_chunkList *output; // output[d]: unsuccessful clears that were moved to depth d
+  size_t lenOutput; // len(output array)
+} * ES_finishedClearSetGrain;
+
 
 bool ES_mark(__attribute__((unused)) GC_state s, objptr op);
 void ES_unmark(GC_state s, objptr op);
@@ -22,6 +38,15 @@ bool ES_contains(HM_chunkList es, objptr op);
 HM_chunkList ES_append(GC_state s, HM_chunkList es1, HM_chunkList es2);
 
 void ES_clear(GC_state s, HM_HierarchicalHeap hh);
+
+// These functions allow us to clear a suspect set in parallel,
+// by integrating with the scheduler. The idea is...
+size_t ES_numSuspects(GC_state s, HM_HierarchicalHeap hh);
+ES_clearSet ES_takeClearSet(GC_state s, HM_HierarchicalHeap hh);
+size_t ES_numChunksInClearSet(GC_state s, ES_clearSet es);
+ES_finishedClearSetGrain ES_processClearSetGrain(GC_state s, ES_clearSet es, size_t start, size_t stop);
+void ES_commitFinishedClearSetGrain(GC_state s, GC_thread thread, ES_finishedClearSetGrain es);
+void ES_deleteClearSet(GC_state s, ES_clearSet es);
 
 void ES_move(HM_chunkList list1, HM_chunkList list2);
 

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -104,7 +104,7 @@ void GC_collect (GC_state s, size_t bytesRequested, bool force) {
 
   // ebr for chunks
   HM_EBR_leaveQuiescentState(s);
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
 
   maybeSample(s, s->blockUsageSampler);
 

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -730,7 +730,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
   }
 
   HM_EBR_leaveQuiescentState(s);
-  HM_EBR_enterQuiescentState(s);
+  // HM_EBR_enterQuiescentState(s);
 
   /* after everything has been scavenged, we have to move the pinned chunks */
   depth = thread->currentDepth + 1;

--- a/runtime/gc/hierarchical-heap.h
+++ b/runtime/gc/hierarchical-heap.h
@@ -160,6 +160,11 @@ void HM_HH_resetList(pointer threadp);
 
 void mergeCompletedCCs(GC_state s, HM_HierarchicalHeap hh);
 
+void HM_HH_clearSuspectsAtDepth(
+  GC_state s,
+  GC_thread thread,
+  uint32_t targetDepth);
+
 
 /** Very fancy (constant-space) loop that frees each dependant union-find
   * node of hh. Specifically, calls this on each dependant ufnode:

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -164,6 +164,18 @@ void GC_HH_promoteChunks(pointer threadp) {
   HM_HH_promoteChunks(s, thread);
 }
 
+void GC_HH_clearSuspectsAtDepth(GC_state s, pointer threadp, uint32_t depth) {
+  getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed(s);
+  getThreadCurrent(s)->exnStack = s->exnStack;
+  HM_HH_updateValues(getThreadCurrent(s), s->frontier);
+  assert(threadAndHeapOkay(s));
+
+  GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));
+  assert(thread != NULL);
+  assert(thread->hierarchicalHeap != NULL);
+  HM_HH_clearSuspectsAtDepth(s, thread, depth);
+}
+
 void GC_HH_moveNewThreadToDepth(pointer threadp, uint32_t depth) {
   GC_state s = pthread_getspecific(gcstate_key);
   GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -176,6 +176,63 @@ void GC_HH_clearSuspectsAtDepth(GC_state s, pointer threadp, uint32_t depth) {
   HM_HH_clearSuspectsAtDepth(s, thread, depth);
 }
 
+Word64 GC_HH_numSuspectsAtDepth(GC_state s, pointer threadp, uint32_t targetDepth) {
+  getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed(s);
+  getThreadCurrent(s)->exnStack = s->exnStack;
+  HM_HH_updateValues(getThreadCurrent(s), s->frontier);
+  assert(threadAndHeapOkay(s));
+  GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));
+  assert(thread != NULL);
+  assert(thread->hierarchicalHeap != NULL);
+
+  for (HM_HierarchicalHeap cursor = thread->hierarchicalHeap;
+       NULL != cursor;
+       cursor = cursor->nextAncestor)
+  {
+    uint32_t d = HM_HH_getDepth(cursor);
+    if (d <= targetDepth) {
+      if (d == targetDepth) return (Word64)ES_numSuspects(s, cursor);
+      return 0;
+    }
+  }
+
+  return 0;
+}
+
+Pointer /*ES_clearSet*/
+GC_HH_takeClearSetAtDepth(GC_state s, pointer threadp, uint32_t targetDepth) {
+  getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed(s);
+  getThreadCurrent(s)->exnStack = s->exnStack;
+  HM_HH_updateValues(getThreadCurrent(s), s->frontier);
+  assert(threadAndHeapOkay(s));
+  GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));
+  assert(thread != NULL);
+  assert(thread->hierarchicalHeap != NULL);
+  return (pointer)ES_takeClearSet(s, HM_HH_getHeapAtDepth(s, thread, targetDepth));
+}
+
+Word64 GC_HH_numChunksInClearSet(GC_state s, pointer clearSet) {
+  return (Word64)ES_numChunksInClearSet(s, (ES_clearSet)clearSet);
+}
+
+Pointer /*ES_finishedClearSetGrain*/
+GC_HH_processClearSetGrain(GC_state s, pointer clearSet, Word64 start, Word64 stop) {
+  return (pointer)ES_processClearSetGrain(s, (ES_clearSet)clearSet, (size_t)start, (size_t)stop);
+}
+
+void GC_HH_commitFinishedClearSetGrain(GC_state s, pointer threadp, pointer finClearSetGrain) {
+  getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed(s);
+  getThreadCurrent(s)->exnStack = s->exnStack;
+  HM_HH_updateValues(getThreadCurrent(s), s->frontier);
+  assert(threadAndHeapOkay(s));
+  GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));
+  ES_commitFinishedClearSetGrain(s, thread, (ES_finishedClearSetGrain)finClearSetGrain);
+}
+
+void GC_HH_deleteClearSet(GC_state s, pointer clearSet) {
+  ES_deleteClearSet(s, (ES_clearSet)clearSet);
+}
+
 void GC_HH_moveNewThreadToDepth(pointer threadp, uint32_t depth) {
   GC_state s = pthread_getspecific(gcstate_key);
   GC_thread thread = threadObjptrToStruct(s, pointerToObjptr(threadp, NULL));

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -129,6 +129,8 @@ PRIVATE void GC_HH_setMinLocalCollectionDepth(pointer thread, Word32 depth);
  */
 PRIVATE void GC_HH_moveNewThreadToDepth(pointer thread, Word32 depth);
 
+PRIVATE void GC_HH_clearSuspectsAtDepth(GC_state s, pointer threadp, uint32_t depth);
+
 PRIVATE Bool GC_HH_checkFinishedCCReadyToJoin(GC_state s);
 
 #endif /* MLTON_GC_INTERNAL_BASIS */

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -131,6 +131,13 @@ PRIVATE void GC_HH_moveNewThreadToDepth(pointer thread, Word32 depth);
 
 PRIVATE void GC_HH_clearSuspectsAtDepth(GC_state s, pointer threadp, uint32_t depth);
 
+PRIVATE Word64 GC_HH_numSuspectsAtDepth(GC_state s, pointer threadp, uint32_t depth);
+PRIVATE Pointer /*ES_clearSet*/ GC_HH_takeClearSetAtDepth(GC_state s, pointer threadp, uint32_t depth);
+PRIVATE Word64 GC_HH_numChunksInClearSet(GC_state s, pointer clearSet);
+PRIVATE Pointer /*ES_finishedClearSetGrain*/ GC_HH_processClearSetGrain(GC_state s, pointer clearSet, Word64 start, Word64 stop);
+PRIVATE void GC_HH_commitFinishedClearSetGrain(GC_state s, pointer threadp, pointer finClearSetGrain);
+PRIVATE void GC_HH_deleteClearSet(GC_state s, pointer clearSet);
+
 PRIVATE Bool GC_HH_checkFinishedCCReadyToJoin(GC_state s);
 
 #endif /* MLTON_GC_INTERNAL_BASIS */


### PR DESCRIPTION
Integrate with the scheduler to clear suspects in parallel. This patch subsumes #167 but I will keep the other open for now, for potential discussion.

**Performance improvements**. Big! On 72 procs, `ms-queue` is now at ~30x speedup over sequential (old: 19x), and `linden-pq` is now at ~36x speedup over sequential (old: ~30x)

**Algorithm description**. The algorithm in this patch is straightforward. Clearing suspects is a bucketed filter: some elements are eliminated, and some survive; each of the survivors is moved into one of $D$ buckets (where $D$ is the depth of the heap whose suspects are being cleared). To parallelize this, we (1) break up the input, (2) run multiple sequential filters in parallel, and then finally (3) merge the results.

**TODO: algorithmic improvements?** This algorithm has three phases. The middle phase is highly parallel, but both the first and last phases are sequential. In the first phase, the algorithm converts the input list (of chunks) into an array (of chunks). In the last phase, it sequentially merges bucketed outputs. Probably neither of these is a performance bottleneck at the moment. But in the future, there are opportunities for more parallelism. **To parallelize the first phase**, we could maintain all suspect sets as balanced trees, to enable fast balanced splitting. **To parallelize the last phase**, we could merge results with a D&C reduction.

**TODO: implementation optimizations?** This particular implementation could be further optimized in a few ways.
  1. Don't rely on malloc/free for intermediate data. Use the block allocator directly instead, to avoid the malloc/free bottleneck.
  2. Free old chunks in parallel. Currently we free these chunks sequentially in `ES_deleteClearSet`. But we could instead free them in `ES_processClearSetGrain`, by eagerly freeing each processed chunk we see along the way.