### PR TITLE
bugfix: update structure One to be thread-safe

### DIFF
--- a/basis-library/util/one.sml
+++ b/basis-library/util/one.sml
@@ -1,5 +1,6 @@
 (* Copyright (C) 2006-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
+ * Copyright (C) 2023 Sam Westrick.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
@@ -13,28 +14,44 @@ structure One:
       val use: 'a t * ('a -> 'b) -> 'b
    end =
    struct
+
+      (* SAM_NOTE: using Word8 instead of bool here to work around the
+       * compilation bug with primitive compareAndSwap... (The compilation
+       * passes splitTypes1 and splitTypes2 cause a crash when compareAndSwap
+       * is used on certain data types, including bool.)
+       *
+       * Here I use 0w0 for false, and 0w1 for true
+       *
+       * When we fix compilation for compareAndSwap, we can switch back
+       * to using bool.
+       *)
+
       datatype 'a t = T of {more: unit -> 'a,
                             static: 'a,
-                            staticIsInUse: bool ref}
+                            staticIsInUse: Primitive.Word8.word ref}
 
       fun make f = T {more = f,
                       static = f (),
-                      staticIsInUse = ref false}
+                      staticIsInUse = ref 0w0}
+
+      val cas = Primitive.MLton.Parallel.compareAndSwap
 
       fun use (T {more, static, staticIsInUse}, f) =
          let
             val () = Primitive.MLton.Thread.atomicBegin ()
-            val b = ! staticIsInUse
+            val claimed =
+               (!staticIsInUse) = 0w0
+               andalso
+               0w0 = cas (staticIsInUse, 0w0, 0w1)
             val d =
-               if b then
+               if not claimed then
                   (Primitive.MLton.Thread.atomicEnd ();
                    more ())
                else
-                  (staticIsInUse := true;
-                   Primitive.MLton.Thread.atomicEnd ();
+                  (Primitive.MLton.Thread.atomicEnd ();
                    static)
         in
            DynamicWind.wind (fn () => f d,
-                             fn () => if b then () else staticIsInUse := false)
+                             fn () => if claimed then staticIsInUse := 0w0 else ())
         end
    end


### PR DESCRIPTION
basis-library/util/one.sml defines a structure called `One` which is used in the basis library to optimize memory usage of a few functions, including:
  * Int.{fmt,toString}
  * Word.{fmt,toString}
  * Real.{split,toManExp}

This patch fixes a buggy race condition in the implementation of `One`. With this patch, the above functions should be safe for parallelism and concurrency.

The idea behind `One` is straightforward: a static buffer or mutable cell is allocated to be shared across calls. When a call is made, if the shared buffer is not in use, then the shared buffer can be claimed and used for the duration of that call, and then released.

The mechanism for claiming the buffer (inherited from MLton) was previously not thread-safe, because it was not atomic at the hardware level. For MLton, it didn't need to be. But for MPL this is no longer correct, hence the bug.

This patch switches to using an atomic compare-and-swap (CAS) to claim the buffer.