### PR TITLE
Fix rssa type check error: word size mismatch

### DIFF
--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1967,17 +1967,17 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                              * if its not set, then proceed with the value in optVar without any readBarrier
                                              * However, if its set, then we need to call the readBarrier
                                              *)
-                                            fun uint_operand n = Operand.word (WordX.fromInt (n, WordSize.shiftArg))
-                                            (* val shift = Operand.word (WordX.one WordSize.shiftArg) *)
-                                            val smask = 0wx40000000
-                                            val smaskint = Word.toInt smask
-                                            val smaskintInf = IntInf.fromInt smaskint
-                                            val mask = Operand.word (WordX.fromIntInf (smaskintInf, WordSize.shiftArg))
-                                            val (crs, ctag) =
-                                             Statement.andb (Offset {base = varOp(Base.object base),
-                                               offset = Runtime.headerOffset (),
-                                               ty = Type.objptrHeader ()}, mask)
-                                            val (crs2, ctag2) = Statement.rshift (ctag, uint_operand 30)
+                                            val mask = Operand.word
+                                              (WordX.fromIntInf (0x40000000, WordSize.objptrHeader ()))
+                                            val (crs, ctag) = Statement.andb
+                                              (Offset
+                                                 {base = varOp(Base.object base),
+                                                  offset = Runtime.headerOffset (),
+                                                  ty = Type.objptrHeader ()},
+                                               mask)
+                                            val (crs2, ctag2) = Statement.rshift
+                                              (ctag,
+                                               Operand.word (WordX.fromInt (30, WordSize.shiftArg)))
                                             val cont_block =
                                              newBlock {args = Vector.new1 finalDst,
                                                 kind = Kind.Jump,


### PR DESCRIPTION
Compiling with `-type-check true` was previously throwing an error for RSSA type checking. The problem was a mismatch between word sizes in the generated code for read barrier fast paths. The generated code used `WordSize.shiftArg` for a mask on an object header. This just needed to be changed to `WordSize.objptrHeader()`.

I cleaned up the code a little, too.