### PR TITLE
Implement `structure Universal` with an applicative exception declaration

### DIFF
--- a/basis-library/schedulers/par-pcall/Universal.sml
+++ b/basis-library/schedulers/par-pcall/Universal.sml
@@ -8,12 +8,12 @@ struct
 
   fun 'a embed () =
     let
-      exception E of 'a
+      exception UnivTag of 'a
       fun project (e: t): 'a option =
         case e of
-          E a => SOME a
+          UnivTag a => SOME a
         | _ => NONE
     in
-      (E, project)
+      (UnivTag, project)
     end
 end

--- a/basis-library/schedulers/par-pcall/sources.mlb
+++ b/basis-library/schedulers/par-pcall/sources.mlb
@@ -26,7 +26,11 @@ local
   ../shh/queue/DequeABP.sml
   (*Stack.sml*)
   ../shh/Result.sml
-  Universal.sml
+  ann
+     "exnDecElab app"
+  in
+     Universal.sml
+  end
   ann
     "allowFFI true"
     "allowPrim true"

--- a/mlton/atoms/atoms.fun
+++ b/mlton/atoms/atoms.fun
@@ -80,6 +80,8 @@ structure Atoms =
                              structure RealSize = RealSize
                              structure WordSize = WordSize)
 
+      structure ExnDecElab = ExnDecElab ()
+
       structure Prod = Prod ()
       structure Handler = Handler (structure Label = Label)
       structure Return = Return (structure Label = Label

--- a/mlton/atoms/atoms.sig
+++ b/mlton/atoms/atoms.sig
@@ -24,6 +24,7 @@ signature ATOMS' =
       structure CharSize: CHAR_SIZE
       structure Con: CON
       structure Const: CONST
+      structure ExnDecElab: EXN_DEC_ELAB
       structure Ffi: FFI
       structure Field: FIELD
       structure Func: FUNC
@@ -95,6 +96,7 @@ signature ATOMS =
       sharing Cases = Atoms.Cases
       sharing Con = Atoms.Con
       sharing Const = Atoms.Const
+      sharing ExnDecElab = Atoms.ExnDecElab
       sharing Ffi = Atoms.Ffi
       sharing Field = Atoms.Field
       sharing Func = Atoms.Func

--- a/mlton/atoms/exn-dec-elab.fun
+++ b/mlton/atoms/exn-dec-elab.fun
@@ -1,0 +1,26 @@
+(* Copyright (C) 2024 Matthew Fluet.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+functor ExnDecElab (S: EXN_DEC_ELAB_STRUCTS): EXN_DEC_ELAB =
+struct
+
+open S
+
+open Control.Elaborate.ExnDecElab
+
+val all = [App, Gen]
+
+val layout = Layout.str o toString
+
+val parse =
+   let
+      open Parse
+      infix 3 *>
+   in
+      any (List.map (all, fn ede => kw (toString ede) *> pure ede))
+   end
+
+end

--- a/mlton/atoms/exn-dec-elab.sig
+++ b/mlton/atoms/exn-dec-elab.sig
@@ -1,0 +1,19 @@
+(* Copyright (C) 2024 Matthew Fluet.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+signature EXN_DEC_ELAB_STRUCTS =
+   sig
+   end
+
+signature EXN_DEC_ELAB =
+   sig
+      include EXN_DEC_ELAB_STRUCTS
+
+      datatype t = App | Gen
+
+      val layout: t -> Layout.t
+      val parse: t Parse.t
+   end

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -15,6 +15,7 @@ signature CHAR_SIZE
 signature CONST
 signature C_FUNCTION
 signature C_TYPE
+signature EXN_DEC_ELAB
 signature HASH_TYPE
 signature ID
 signature INT_SIZE
@@ -108,6 +109,8 @@ cases.sig
 cases.fun
 prim.sig
 prim.fun
+exn-dec-elab.sig
+exn-dec-elab.fun
 prod.sig
 prod.fun
 handler.sig

--- a/mlton/atoms/sources.mlb
+++ b/mlton/atoms/sources.mlb
@@ -70,6 +70,8 @@ local
    cases.fun
    prim.sig
    prim.fun
+   exn-dec-elab.sig
+   exn-dec-elab.fun
    prod.sig
    prod.fun
    handler.sig
@@ -97,6 +99,7 @@ in
    signature CONST
    signature C_FUNCTION
    signature C_TYPE
+   signature EXN_DEC_ELAB
    signature HASH_TYPE
    signature ID
    signature INT_SIZE

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -134,6 +134,12 @@ signature CONTROL_FLAGS =
                      Default
                    | Ignore
                end
+            structure ExnDecElab :
+               sig
+                  datatype t = App | Gen
+                  val toString: t -> string
+               end
+
             structure ResolveScope :
                sig
                   datatype t =
@@ -154,6 +160,7 @@ signature CONTROL_FLAGS =
             val allowRedefineSpecialIds: (bool,bool) t
             val allowSpecifySpecialIds: (bool,bool) t
             val deadCode: (bool,bool) t
+            val exnDecElab: (ExnDecElab.t,ExnDecElab.t) t
             val forceUsed: (unit,bool) t
             val ffiStr: (string,string option) t
             val nonexhaustiveBind: (DiagEIW.t,DiagEIW.t) t

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -356,6 +356,20 @@ structure Elaborate =
                 | Ignore => "ignore"
          end
 
+      structure ExnDecElab =
+         struct
+            datatype t = App | Gen
+
+            val fromString: string -> t option =
+               fn "app" => SOME App
+                | "gen" => SOME Gen
+                | _ => NONE
+
+            val toString: t -> string =
+               fn App => "app"
+                | Gen => "gen"
+         end
+
       structure ResolveScope =
          struct
             datatype t =
@@ -658,6 +672,19 @@ structure Elaborate =
          val (deadCode, ac) =
             makeBool ({name = "deadCode",
                        default = false, expert = true}, ac)
+         val (exnDecElab, ac) =
+            make ({choices = SOME [ExnDecElab.App, ExnDecElab.Gen],
+                   default = ExnDecElab.Gen,
+                   expert = true,
+                   toString = ExnDecElab.toString,
+                   name = "exnDecElab",
+                   newCur = fn (_,ede) => ede,
+                   newDef = fn (_,ede) => ede,
+                   parseArgs = fn args' =>
+                               case args' of
+                                  [arg'] => ExnDecElab.fromString arg'
+                                | _ => NONE},
+                  ac)
          val (forceUsed, ac) =
             make ({choices = NONE,
                    default = false,

--- a/mlton/core-ml/core-ml.fun
+++ b/mlton/core-ml/core-ml.fun
@@ -166,7 +166,8 @@ datatype dec =
                 tycon: Tycon.t,
                 tyvars: Tyvar.t vector} vector
  | Exception of {arg: Type.t option,
-                 con: Con.t}
+                 con: Con.t,
+                 elab: ExnDecElab.t}
  | Fun of {decs: {lambda: lambda,
                   var: Var.t} vector,
            tyvars: unit -> Tyvar.t vector}
@@ -248,8 +249,11 @@ in
                         align
                         (separateLeft (Vector.toListMap (cons, layoutConArg),
                                        "| "))]))]
-       | Exception ca =>
-            seq [str "exception ", layoutConArg ca]
+       | Exception {con, arg, elab} =>
+            seq [str "exception ",
+                 ExnDecElab.layout elab,
+                 str " ",
+                 layoutConArg {con = con, arg = arg}]
        | Fun {decs, tyvars, ...} => layoutFuns (tyvars, decs)
        | Val {rvbs, tyvars, vbs, ...} =>
             align [layoutFuns (tyvars, rvbs),

--- a/mlton/core-ml/core-ml.sig
+++ b/mlton/core-ml/core-ml.sig
@@ -163,7 +163,8 @@ signature CORE_ML =
                             tycon: Tycon.t,
                             tyvars: Tyvar.t vector} vector
              | Exception of {arg: Type.t option,
-                             con: Con.t}
+                             con: Con.t,
+                             elab: ExnDecElab.t}
              | Fun of {decs: {lambda: Lambda.t,
                               var: Var.t} vector,
                        tyvars: unit -> Tyvar.t vector}

--- a/mlton/defunctorize/defunctorize.fun
+++ b/mlton/defunctorize/defunctorize.fun
@@ -744,9 +744,10 @@ fun defunctorize (CoreML.Program.T {decs}) =
          in
             case d of
                Datatype _ => e
-             | Exception {arg, con} =>
+             | Exception {arg, con, elab} =>
                   prefix (Xdec.Exception {arg = Option.map (arg, loopTy),
-                                          con = con})
+                                          con = con,
+                                          elab = elab})
              | Fun {decs, tyvars} =>
                   prefix (Xdec.Fun {decs = processLambdas decs,
                                     tyvars = tyvars ()})

--- a/mlton/elaborate/elaborate-core.fun
+++ b/mlton/elaborate/elaborate-core.fun
@@ -15,6 +15,7 @@ open S
 local
    open Control.Elaborate
 in
+   val exnDecElab = fn () => current exnDecElab
    val nonexhaustiveBind = fn () => current nonexhaustiveBind
    val nonexhaustiveExnBind = fn () => current nonexhaustiveExnBind
    val nonexhaustiveExnMatch = fn () => current nonexhaustiveExnMatch
@@ -137,6 +138,7 @@ in
    structure Convention = CFunction.Convention
    structure Cdec = Dec
    structure Cexp = Exp
+   structure ExnDecElab = ExnDecElab
    structure Ffi = Ffi
    structure IntSize = IntSize
    structure Lambda = Lambda
@@ -2336,10 +2338,17 @@ fun elaborateDec (d, {env = E, nest}) =
                                                      end
                                             val scheme = Scheme.fromType ty
                                             val _ = Env.extendExn (E, exn, exn', scheme)
+                                            val elab =
+                                               case exnDecElab () of
+                                                  Control.Elaborate.ExnDecElab.App =>
+                                                     ExnDecElab.App
+                                                | Control.Elaborate.ExnDecElab.Gen =>
+                                                     ExnDecElab.Gen
                                          in
                                             Decs.add (decs,
                                                       Cdec.Exception {arg = arg,
-                                                                      con = exn'})
+                                                                      con = exn',
+                                                                      elab = elab})
                                          end
                              in
                                 decs

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -225,7 +225,8 @@ local
          List.concat [[Datatype primitiveDatatypes],
                       List.map
                       (primitiveExcons, fn c =>
-                       Exception {con = c, arg = NONE})]
+                       Exception {con = c, arg = NONE,
+                                  elab = CoreML.ExnDecElab.Gen})]
       end
 
 in

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -408,14 +408,15 @@ fun monomorphise (Xprogram.T {datatypes, body, ...}): Sprogram.t =
                                       lambda = lambda}
                                   end))})))
                 end
-           | Xdec.Exception {con, arg} =>
+           | Xdec.Exception {con, arg, elab} =>
                 let
                    val con' = Con.new con
                    val _ = setCon (con, fn _ => con')
                 in
                    fn () =>
                    [Sdec.Exception {con = con',
-                                    arg = monoTypeOpt arg}]
+                                    arg = monoTypeOpt arg,
+                                    elab = elab}]
                 end) arg
       (*------------------------------------*)
       (*     main code for monomorphise     *)

--- a/mlton/xml/simplify-types.fun
+++ b/mlton/xml/simplify-types.fun
@@ -196,9 +196,10 @@ fun simplifyTypes (I.Program.T {body, datatypes}) =
                   targs = fixConTargs (con, targs)}
       fun fixDec (d: I.Dec.t): O.Dec.t =
          case d of
-            I.Dec.Exception {arg, con} =>
+            I.Dec.Exception {arg, con, elab} =>
                O.Dec.Exception {arg = Option.map (arg, fixType),
-                                con = con}
+                                con = con,
+                                elab = elab}
           | I.Dec.Fun {decs, tyvars} =>
                let
                   val decs =

--- a/mlton/xml/type-check.fun
+++ b/mlton/xml/type-check.fun
@@ -284,7 +284,8 @@ fun typeCheck (program as Program.T {datatypes, body}): unit =
             val check = fn (t, t') => check (t, t', fn () => Dec.layout d)
          in
             case d of
-               Exception c => setCon (c, Vector.new0 (), Type.exn)
+               Exception {arg, con, ...} =>
+                  setCon ({arg = arg, con = con}, Vector.new0 (), Type.exn)
              | Fun {tyvars, decs} =>
                   (bindTyvars tyvars
                    ; (Vector.foreach

--- a/mlton/xml/xml-tree.sig
+++ b/mlton/xml/xml-tree.sig
@@ -110,7 +110,8 @@ signature XML_TREE =
 
             datatype t =
                Exception of {arg: Type.t option,
-                             con: Con.t}
+                             con: Con.t,
+                             elab: ExnDecElab.t}
              | Fun of {decs: {lambda: Lambda.t,
                               ty: Type.t,
                               var: Var.t} vector,


### PR DESCRIPTION
@shwestrick @colin-mcd @mikerainey 

A simple approach to avoiding the `unit ref` allocation with `structure Universal`.  Read a4eb2010b2188b6d90e830232a230e609269fc4b's commit message for the interesting details.

It will be interesting to see if this has any impact on performance.  A `unit ref` allocation ought to be just two instructions: `*frontier = header(unit ref); frontier += 8;`.  And, I guess there would be a third instruction to write the object pointer to the freshly allocated `unit ref` to the stack, in order to be live across the `pcall` and accessible in the `par` and `spwn` continuations.

If it doesn't have any impact on performance, then I wonder whether avoiding the `Universal.t` entirely and just doing the `val rightSideResult = 'b option ref` allocation in `pcallFork` is really as bad as feared.  (We would still allocate the rest of the joint point in the signal handler, passed to the `par` and `spwn` continuations via the data pointer; then we can just pass the `rightSideResult` along with the `jp` fetched via `getData` to the real synchronization operation.  Or, maybe it is simpler for the signal handler to allocate a `pre_joinpoint` (monomorphic, with no `rightSideResult` field), which is propagated to the `par` and `spwn` continuations, who combine the `pre_joinpoint` with the `rightSideResult` to yield a `'b joinpoint`.)
