### PR TITLE
add prim `Heartbeat_tokens` for a faster `par` fast path

### DIFF
--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -67,6 +67,7 @@ datatype 'a t =
  | Exn_setExtendExtra (* implement exceptions *)
  | GC_collect (* to rssa (as runtime C fn) *)
  | GC_state (* to rssa (as operand) *)
+ | Heartbeat_tokens (* to rssa (as operand) *)
  | IntInf_add (* to rssa (as runtime C fn) *)
  | IntInf_andb (* to rssa (as runtime C fn) *)
  | IntInf_arshift (* to rssa (as runtime C fn) *)
@@ -262,6 +263,7 @@ fun toString (n: 'a t): string =
        | Exn_setExtendExtra => "Exn_setExtendExtra"
        | GC_collect => "GC_collect"
        | GC_state => "GC_state"
+       | Heartbeat_tokens => "Heartbeat_tokens"
        | IntInf_add => "IntInf_add"
        | IntInf_andb => "IntInf_andb"
        | IntInf_arshift => "IntInf_arshift"
@@ -425,6 +427,7 @@ val equals: 'a t * 'a t -> bool =
     | (Exn_setExtendExtra, Exn_setExtendExtra) => true
     | (GC_collect, GC_collect) => true
     | (GC_state, GC_state) => true
+    | (Heartbeat_tokens, Heartbeat_tokens) => true
     | (IntInf_add, IntInf_add) => true
     | (IntInf_andb, IntInf_andb) => true
     | (IntInf_arshift, IntInf_arshift) => true
@@ -609,6 +612,7 @@ val map: 'a t * ('a -> 'b) -> 'b t =
     | Exn_setExtendExtra => Exn_setExtendExtra
     | GC_collect => GC_collect
     | GC_state => GC_state
+    | Heartbeat_tokens => Heartbeat_tokens
     | IntInf_add => IntInf_add
     | IntInf_andb => IntInf_andb
     | IntInf_arshift => IntInf_arshift
@@ -819,6 +823,7 @@ val kind: 'a t -> Kind.t =
        | Exn_setExtendExtra => SideEffect
        | GC_collect => SideEffect
        | GC_state => DependsOnState
+       | Heartbeat_tokens => DependsOnState (* SAM_NOTE: check? *)
        | IntInf_add => Functional
        | IntInf_andb => Functional
        | IntInf_arshift => Functional
@@ -1029,6 +1034,7 @@ in
        Exn_setExtendExtra,
        GC_collect,
        GC_state,
+       Heartbeat_tokens,
        IntInf_add,
        IntInf_andb,
        IntInf_arshift,
@@ -1364,6 +1370,7 @@ fun 'a checkApp (prim: 'a t,
        | Exn_setExtendExtra => oneTarg (fn t => (oneArg (arrow (t, t)), unit))
        | GC_collect => noTargs (fn () => (noArgs, unit))
        | GC_state => noTargs (fn () => (noArgs, cpointer))
+       | Heartbeat_tokens => noTargs (fn () => (noArgs, word32))
        | IntInf_add => intInfBinary ()
        | IntInf_andb => intInfBinary ()
        | IntInf_arshift => intInfShift ()

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -57,6 +57,7 @@ signature PRIM =
        | Exn_setExtendExtra (* implement exceptions *)
        | GC_collect (* to rssa (as runtime C fn) *)
        | GC_state (* to rssa (as operand) *)
+       | Heartbeat_tokens (* to rssa (as operand) *)
        | IntInf_add (* to rssa (as runtime C fn) *)
        | IntInf_andb (* to rssa (as runtime C fn) *)
        | IntInf_arshift (* to rssa (as runtime C fn) *)

--- a/mlton/backend/rep-type.fun
+++ b/mlton/backend/rep-type.fun
@@ -728,6 +728,7 @@ fun ofGCField (f: GCField.t): t =
        | Limit => cpointer ()
        | LimitPlusSlop => cpointer ()
        | SignalIsPending => word32
+       | SpareHeartbeatTokens => word32
        | StackBottom => cpointer ()
        | StackLimit => cpointer ()
        | StackTop => cpointer ()

--- a/mlton/backend/runtime.fun
+++ b/mlton/backend/runtime.fun
@@ -21,6 +21,7 @@ structure GCField =
        | Limit
        | LimitPlusSlop
        | SignalIsPending
+       | SpareHeartbeatTokens
        | StackBottom
        | StackLimit
        | StackTop
@@ -40,6 +41,7 @@ structure GCField =
              | Limit => make "limit"
              | LimitPlusSlop => make "limitPlusSlop"
              | SignalIsPending => make "signalsInfo.signalIsPending"
+             | SpareHeartbeatTokens => make "spareHeartbeatTokens"
              | StackBottom => make "stackBottom"
              | StackLimit => make "stackLimit"
              | StackTop => make "stackTop"
@@ -53,6 +55,7 @@ structure GCField =
           | Limit => "Limit"
           | LimitPlusSlop => "LimitPlusSlop"
           | SignalIsPending => "SignalIsPending"
+          | SpareHeartbeatTokens => "SpareHeartbeatTokens"
           | StackBottom => "StackBottom"
           | StackLimit => "StackLimit"
           | StackTop => "StackTop"

--- a/mlton/backend/runtime.sig
+++ b/mlton/backend/runtime.sig
@@ -25,6 +25,7 @@ signature RUNTIME =
              | Limit (* frontier + heapSize - LIMIT_SLOP *)
              | LimitPlusSlop (* frontier + heapSize *)
              | SignalIsPending
+             | SpareHeartbeatTokens
              | StackBottom
              | StackLimit (* Must have StackTop <= StackLimit *)
              | StackTop (* Points at the next available byte on the stack. *)

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1615,6 +1615,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                      func = (CFunction.gc
                                              {maySwitchThreads = handlesSignals})}
                                | Prim.GC_state => move GCState
+                               | Prim.Heartbeat_tokens => move (Runtime GCField.SpareHeartbeatTokens)
                                | Prim.IntInf_add =>
                                     simpleCCallWithGCState (CFunction.intInfBinary prim)
                                | Prim.IntInf_andb =>

--- a/runtime/gc/copy-thread.c
+++ b/runtime/gc/copy-thread.c
@@ -62,8 +62,8 @@ GC_thread copyThreadWithHeap (GC_state s, GC_thread from, size_t used) {
   to->bytesNeeded = from->bytesNeeded;
   to->exnStack = from->exnStack;
 
-  to->spareHeartbeats += from->spareHeartbeats;
-  from->spareHeartbeats = 0;
+  to->spareHeartbeatTokens += from->spareHeartbeatTokens;
+  from->spareHeartbeatTokens = 0;
 
 #ifdef DETECT_ENTANGLEMENT
   memcpy(

--- a/runtime/gc/enter_leave.c
+++ b/runtime/gc/enter_leave.c
@@ -19,7 +19,7 @@ void enter (GC_state s) {
   /* used needs to be set because the mutator has changed s->stackTop. */
   getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed (s);
   getThreadCurrent(s)->exnStack = s->exnStack;
-  getThreadCurrent(s)->spareHeartbeats = s->spareHeartbeats;
+  getThreadCurrent(s)->spareHeartbeatTokens = s->spareHeartbeatTokens;
   HM_HH_updateValues(getThreadCurrent(s), s->frontier);
   HH_EBR_leaveQuiescentState(s);
   HM_EBR_leaveQuiescentState(s);
@@ -40,7 +40,7 @@ void leave (GC_state s) {
    * for functions that don't ensureBytesFree.
    */
   assert(invariantForMutator(s, FALSE, TRUE));
-  s->spareHeartbeats = getThreadCurrent(s)->spareHeartbeats;
+  s->spareHeartbeatTokens = getThreadCurrent(s)->spareHeartbeatTokens;
   endAtomic (s);
   // Trace0(EVENT_RUNTIME_LEAVE);
 }

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -43,7 +43,7 @@ void setGCStateCurrentThreadAndStack (GC_state s) {
   GC_stack stack;
 
   thread = getThreadCurrent (s);
-  s->spareHeartbeats = thread->spareHeartbeats;
+  s->spareHeartbeatTokens = thread->spareHeartbeatTokens;
   s->exnStack = thread->exnStack;
   stack = getStackCurrent (s);
   s->stackBottom = getStackBottom (s, stack);

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -18,7 +18,7 @@ struct GC_state {
    * size and improve cache performance.
    */
   pointer frontier;
-  uint32_t spareHeartbeats;
+  uint32_t spareHeartbeatTokens;
   volatile pointer limit;
   volatile pointer stackTop; /* Top of stack in current thread. */
   pointer stackLimit; /* stackBottom + stackSize - maxFrameSize */

--- a/runtime/gc/handler.c
+++ b/runtime/gc/handler.c
@@ -290,7 +290,7 @@ pointer GC_handlerEnterHeapOfThread(GC_state s, objptr threadp) {
   HM_HierarchicalHeap abandonedHH = getThreadCurrent(s)->hierarchicalHeap;
 
   // copy thread details to current thread
-  getThreadCurrent(s)->spareHeartbeats = target->spareHeartbeats;
+  getThreadCurrent(s)->spareHeartbeatTokens = target->spareHeartbeatTokens;
   getThreadCurrent(s)->currentDepth = target->currentDepth;
   getThreadCurrent(s)->currentChunk = target->currentChunk;
   getThreadCurrent(s)->hierarchicalHeap = target->hierarchicalHeap;
@@ -353,7 +353,7 @@ void GC_handlerLeaveHeapOfThread(
   assert(target->currentProcNum == -1);
   assert(s->savedThreadDuringSignalHandler == threadp);
 
-  target->spareHeartbeats = getThreadCurrent(s)->spareHeartbeats;
+  target->spareHeartbeatTokens = getThreadCurrent(s)->spareHeartbeatTokens;
   target->currentDepth = getThreadCurrent(s)->currentDepth;
   target->currentChunk = getThreadCurrent(s)->currentChunk;
   target->hierarchicalHeap = getThreadCurrent(s)->hierarchicalHeap;
@@ -380,7 +380,7 @@ void GC_handlerLeaveHeapOfThread(
   HM_HierarchicalHeap originalHH = (HM_HierarchicalHeap)abandonedHH;
   assert(HM_HH_getDepth(originalHH) == 0);
 
-  getThreadCurrent(s)->spareHeartbeats = 0;
+  getThreadCurrent(s)->spareHeartbeatTokens = 0;
   getThreadCurrent(s)->currentDepth = 0;
   getThreadCurrent(s)->hierarchicalHeap = originalHH;
   getThreadCurrent(s)->bytesAllocatedSinceLastCollection = 0;

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -330,8 +330,8 @@ void HM_HH_merge(
   /* Merge levels. */
   parentThread->hierarchicalHeap = HM_HH_zip(s, parentHH, childHH);
 
-  parentThread->spareHeartbeats += childThread->spareHeartbeats;
-  //parentThread->spareHeartbeats = min(parentThread->spareHeartbeats, 100);
+  parentThread->spareHeartbeatTokens += childThread->spareHeartbeatTokens;
+  //parentThread->spareHeartbeatTokens = min(parentThread->spareHeartbeatTokens, 100);
 
   parentThread->bytesSurvivedLastCollection +=
     childThread->bytesSurvivedLastCollection;

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -126,7 +126,7 @@ GC_thread initThreadAndHeap(GC_state s, uint32_t depth) {
   GC_thread thread =
     newThreadWithHeap(s, sizeofStackInitialReserved(s), depth);
 
-  s->spareHeartbeats = thread->spareHeartbeats;
+  s->spareHeartbeatTokens = thread->spareHeartbeatTokens;
   s->frontier = HM_HH_getFrontier(thread);
   s->limitPlusSlop = HM_HH_getLimit(thread);
   s->limit = s->limitPlusSlop - GC_HEAP_LIMIT_SLOP;

--- a/runtime/gc/new-object.c
+++ b/runtime/gc/new-object.c
@@ -101,7 +101,7 @@ GC_thread newThread(GC_state s, size_t reserved) {
   res = newObject(s, GC_THREAD_HEADER, sizeofThread(s));
   thread = (GC_thread)(res + offsetofThread(s));
   /* a fresh thread is not currently being executed by any processor */
-  thread->spareHeartbeats = 0;
+  thread->spareHeartbeatTokens = 0;
   thread->currentProcNum = -1;
   thread->bytesNeeded = 0;
   thread->exnStack = BOGUS_EXN_STACK;
@@ -184,7 +184,7 @@ GC_thread newThreadWithHeap(
   stack->reserved = reserved;
   stack->used = 0;
 
-  thread->spareHeartbeats = 0;
+  thread->spareHeartbeatTokens = 0;
   thread->currentProcNum = -1;
   thread->bytesNeeded = 0;
   thread->exnStack = BOGUS_EXN_STACK;

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -378,24 +378,18 @@ void GC_HH_joinIntoParent(
 }
 
 
-
-uint32_t GC_currentSpareHeartbeats(GC_state s) {
-  return s->spareHeartbeats;
-}
-
-
 uint32_t GC_addSpareHeartbeats(GC_state s, uint32_t spares) {
-  uint32_t current = s->spareHeartbeats;
-  s->spareHeartbeats = min(current+spares, s->controls->heartbeatTokens);
-  return s->spareHeartbeats;
+  uint32_t current = s->spareHeartbeatTokens;
+  s->spareHeartbeatTokens = min(current+spares, s->controls->heartbeatTokens);
+  return s->spareHeartbeatTokens;
 }
 
 
 Bool GC_tryConsumeSpareHeartbeats(GC_state s, uint32_t count) {
-  uint32_t spares = s->spareHeartbeats;
+  uint32_t spares = s->spareHeartbeatTokens;
   if (spares >= count) {
     // LOG(LM_PARALLEL, LL_FORCE, "success (count = %u). new spares = %u", count, spares - count);
-    s->spareHeartbeats -= count;
+    s->spareHeartbeatTokens -= count;
     return TRUE;
   }
   return FALSE;
@@ -498,10 +492,10 @@ objptr GC_HH_forkThread(GC_state s, pointer threadp, pointer dp) {
   // fork with this function.
   GC_HH_copySyncDepthsFromThread(s, getThreadCurrentObjptr(s), copiedp, newDepth);
 
-  // uint32_t spares = getThreadCurrent(s)->spareHeartbeats;
+  // uint32_t spares = getThreadCurrent(s)->spareHeartbeatTokens;
   // uint32_t half = (spares == 0) ? 0 : min(spares-1, spares >> 1);
-  // copied->spareHeartbeats += half;
-  // getThreadCurrent(s)->spareHeartbeats -= half;
+  // copied->spareHeartbeatTokens += half;
+  // getThreadCurrent(s)->spareHeartbeatTokens -= half;
 
   leave(s);
   return pointerToObjptr((pointer)copied - offsetofThread(s), NULL);

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -41,7 +41,7 @@
 typedef struct GC_thread {
 
   /* unspent heartbeats */
-  uint32_t spareHeartbeats;
+  uint32_t spareHeartbeatTokens;
 
   int32_t currentProcNum; /* the worker currently executing this thread */
   size_t bytesNeeded;
@@ -73,7 +73,7 @@ typedef struct GC_thread {
 
 COMPILE_TIME_ASSERT(GC_thread__packed,
                     sizeof(struct GC_thread) ==
-                    sizeof(uint32_t) + // spareHeartbeats
+                    sizeof(uint32_t) + // spareHeartbeatTokens
                     sizeof(int32_t) +  // currentProcNum
                     sizeof(size_t) +  // bytesNeeded
                     sizeof(ptrdiff_t) +  // exnStack
@@ -91,7 +91,7 @@ COMPILE_TIME_ASSERT(GC_thread__packed,
 
 COMPILE_TIME_ASSERT(GC_thread__packed,
                     sizeof(struct GC_thread) ==
-                    sizeof(uint32_t) + // spareHeartbeats
+                    sizeof(uint32_t) + // spareHeartbeatTokens
                     sizeof(int32_t) +  // currentProcNum
                     sizeof(size_t) +  // bytesNeeded
                     sizeof(ptrdiff_t) +  // exnStack
@@ -148,8 +148,6 @@ PRIVATE Bool GC_tryConsumeSpareHeartbeats(GC_state s, uint32_t count);
 
 // returns new count
 PRIVATE uint32_t GC_addSpareHeartbeats(GC_state s, uint32_t spares);
-
-PRIVATE uint32_t GC_currentSpareHeartbeats(GC_state s);
 
 PRIVATE void GC_HH_joinIntoParentBeforeFastClone(GC_state s, pointer threadp, uint32_t newDepth, uint64_t tidLeft, uint64_t tidRight);
 PRIVATE void GC_HH_joinIntoParent(GC_state s, pointer threadp, pointer rightSideThreadp, uint32_t newDepth, uint64_t tidLeft, uint64_t tidRight);

--- a/runtime/gen/gen-constants.c
+++ b/runtime/gen/gen-constants.c
@@ -63,6 +63,7 @@ int main (__attribute__ ((unused)) int argc,
   MkGCFieldOffset (limit);
   MkGCFieldOffset (limitPlusSlop);
   MkGCFieldOffset (signalsInfo.signalIsPending);
+  MkGCFieldOffset (spareHeartbeatTokens);
   MkGCFieldOffset (sourceMaps.curSourceSeqIndex);
   MkGCFieldOffset (stackBottom);
   MkGCFieldOffset (stackLimit);


### PR DESCRIPTION
A small change which avoids a C runtime call on the fast path of `ForkJoin.par`. The purpose of this C call, previously, was just to read and return the `spareHeartbeatTokens` field of the GCState.

We can avoid the overhead of the C runtime call by generating the appropriate code to read directly from the GCState. To do this, I implemented a new prim called `Heartbeat_tokens` which is eliminated in the `ssa2-to-rssa` pass.

I also renamed `spareHeartbeats` -> `spareHeartbeatTokens` in the runtime system for consistency.