### PR TITLE
 Store PCall alternate return addresses in frame info

### DIFF
--- a/mlton/backend/allocate-variables.fun
+++ b/mlton/backend/allocate-variables.fun
@@ -571,7 +571,8 @@ fun allocate {function = f: Rssa.Function.t,
                         | SOME {handlerOffset, ...} =>
                              Bytes.+ (handlerOffset, Runtime.labelSize ()))
                  | Kind.Jump => mkSize Bytes.zero
-                 | Kind.PCallReturn _ => mkSize (Bytes.* (Runtime.labelSize (), 3))
+                 | Kind.PCallReturn _ =>
+                          mkSize (Bytes.+ (Runtime.labelSize (), Runtime.objptrSize ()))
              val _ =
                 if Bytes.isAligned (size, {alignment = (case !Control.align of
                                                            Control.Align4 => Bytes.inWord32

--- a/mlton/backend/machine.sig
+++ b/mlton/backend/machine.sig
@@ -211,6 +211,19 @@ signature MACHINE =
             val offsets: t -> Bytes.t vector
          end
 
+      structure PCallInfo:
+         sig
+            type t
+
+            val equals: t * t -> bool
+            val hash: t -> word
+            val index: t -> int
+            val layout: t -> Layout.t
+            val new: {index: int, parl: Label.t, parr: Label.t} -> t
+            val parl: t -> Label.t
+            val parr: t -> Label.t
+         end
+
       structure FrameInfo:
          sig
             structure Kind:
@@ -240,7 +253,9 @@ signature MACHINE =
                       index: int,
                       kind: Kind.t,
                       size: Bytes.t,
+                      pcallInfo: PCallInfo.t option,
                       sourceSeqIndex: int option} -> t
+            val pcallInfo: t -> PCallInfo.t option
             val offsets: t -> Bytes.t vector
             val setIndex: t * int -> unit
             val size: t -> Bytes.t
@@ -309,6 +324,7 @@ signature MACHINE =
                             label: Label.t},
                      maxFrameSize: Bytes.t,
                      objectTypes: Type.ObjectType.t vector,
+                     pcallInfos: PCallInfo.t vector,
                      sourceMaps: SourceMaps.t option,
                      staticHeaps: StaticHeap.Kind.t -> StaticHeap.Object.t vector}
 

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -27,6 +27,7 @@ structure C =
    struct
       val truee = "TRUE"
       val falsee = "FALSE"
+      val null = "NULL"
 
       fun bool b = if b then truee else falsee
 
@@ -248,11 +249,43 @@ fun outputDeclarations
     includes: string list,
     print: string -> unit,
     program = (Program.T
-               {frameInfos, frameOffsets, globals, maxFrameSize,
-                objectTypes, sourceMaps, staticHeaps, ...}),
+               {chunks, frameInfos, frameOffsets, globals, maxFrameSize,
+                objectTypes, pcallInfos, sourceMaps, staticHeaps, ...}),
     rest: unit -> unit
     }: unit =
    let
+      val {get = labelInfo: Label.t -> {index: int option},
+           set = setLabelInfo, ...} =
+         Property.getSetOnce
+         (Label.plist, Property.initRaise ("CCodeGen.labelInfo", Label.layout))
+      val _ =
+         List.foreach
+         (chunks, fn Chunk.T {blocks, ...} =>
+          Vector.foreach
+          (blocks, fn block as Block.T {kind, label, ...} =>
+           let
+              val index =
+                 case Kind.frameInfoOpt kind of
+                    NONE => NONE
+                  | SOME fi =>
+                       let
+                          val index = FrameInfo.index fi
+                       in
+                          SOME index
+                       end
+           in
+              setLabelInfo (label, {index = index})
+           end))
+      val labelIndex = valOf o #index o labelInfo
+      fun labelIndexAsString (l, {pretty}) =
+         let
+            val s = C.int (labelIndex l)
+         in
+            if pretty
+               then concat ["/* ", Label.toString l, " */ ", s]
+               else s
+         end
+
       fun prints ss = List.foreach (ss, print)
       fun declareExports () =
          Ffi.declareExports {print = print}
@@ -657,12 +690,26 @@ fun outputDeclarations
                          {firstElemLen = true, oneline = true},
                          FrameOffsets.offsets fo,
                          fn (_, offset) => C.bytes offset))
+          ; Vector.foreachi
+            (pcallInfos, fn (i, pra) =>
+             prints ["const struct GC_pcallInfo ",
+                     "pcallInfo",
+                     C.int i,
+                     " = {",
+                     labelIndexAsString (PCallInfo.parl pra, {pretty = true}),
+                     ",",
+                     labelIndexAsString (PCallInfo.parr pra, {pretty = true}),
+                     "};\n"])
           ; declareArray ("const struct GC_frameInfo", "frameInfos",
                           {firstElemLen = false, oneline = false},
                           frameInfos, fn (_, fi) =>
-                       concat ["{",
+                          concat ["{",
                                   FrameInfo.Kind.toString (FrameInfo.kind fi),
                                   ", frameOffsets", C.int (FrameOffsets.index (FrameInfo.frameOffsets fi)),
+                                  ", ", case FrameInfo.pcallInfo fi of
+                                           NONE => C.null
+                                         | SOME pra => concat ["&pcallInfo",
+                                                               C.int (PCallInfo.index pra)],
                                   ", ", C.bytes (FrameInfo.size fi),
                                   ", ", (case FrameInfo.sourceSeqIndex fi of
                                             NONE => C.int 0
@@ -1390,27 +1437,8 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, ...},
                          ; jump label)
                    | Goto dst => gotoLabel (dst, {tab = true})
                    | PCall {label, cont, parl, parr, size, ...} =>
-                        let
-                           val _ =
-                              outputStatement
-                              (Statement.Move
-                               {dst = Operand.stackOffset
-                                      {offset = Bytes.- (size, Bytes.* (Runtime.labelSize (), 3)),
-                                       ty = Type.label parr,
-                                       volatile = false},
-                                 src = Operand.Label parr})
-                           val _ =
-                              outputStatement
-                              (Statement.Move
-                               {dst = Operand.stackOffset
-                                      {offset = Bytes.- (size, Bytes.* (Runtime.labelSize (), 2)),
-                                       ty = Type.label parl,
-                                       volatile = false},
-                                src = Operand.Label parl})
-                        in
-                           push (cont, size)
-                           ; jump label
-                        end
+                        (push (cont, size)
+                         ; jump label)
                    | Raise {raisesTo} =>
                         (outputStatement (Statement.PrimApp
                                           {args = Vector.new2

--- a/runtime/gc/frame.h
+++ b/runtime/gc/frame.h
@@ -31,11 +31,18 @@ typedef uintptr_t GC_returnAddress;
  * recording the size of the array) whose elements record byte offsets
  * from the bottom of the frame at which live heap pointers are
  * located.  The size field indicates the size of the frame, including
- * space for the return address.  The sourceSeqIndex field indicates
- * the sequence of source names corresponding to the frame as an index
- * into sourceSeqs; see sources.h.
+ * space for the return address.  The pcallInfo field indicates the
+ * alternate return addresses of a PCALL_CONT_FRAME.  The
+ * sourceSeqIndex field indicates the sequence of source names
+ * corresponding to the frame as an index into sourceSeqs; see
+ * sources.h.
  */
 typedef const uint16_t *GC_frameOffsets;
+
+typedef const struct GC_pcallInfo {
+  GC_returnAddress parl;
+  GC_returnAddress parr;
+} *GC_pcallInfo;
 
 typedef enum {
   CONT_FRAME,
@@ -50,6 +57,7 @@ typedef enum {
 typedef const struct GC_frameInfo {
   const GC_frameKind kind;
   const GC_frameOffsets offsets;
+  const GC_pcallInfo pcallInfo;
   const uint16_t size;
   const GC_sourceSeqIndex sourceSeqIndex;
 } *GC_frameInfo;

--- a/runtime/gc/frame.h
+++ b/runtime/gc/frame.h
@@ -9,6 +9,10 @@
 
 #if (defined (MLTON_GC_INTERNAL_TYPES))
 
+typedef uintptr_t GC_returnAddress;
+#define GC_RETURNADDRESS_SIZE sizeof(GC_returnAddress)
+#define FMTRA "0x%016"PRIxPTR
+
 /*
  * The "... reserved bytes ..." of a stack object constitute a linear
  * sequence of frames.  For the purposes of garbage collection and
@@ -52,10 +56,6 @@ typedef const struct GC_frameInfo {
 typedef uint32_t GC_frameIndex;
 #define PRIFI PRIu32
 #define FMTFI "%"PRIFI
-
-typedef uintptr_t GC_returnAddress;
-#define GC_RETURNADDRESS_SIZE sizeof(GC_returnAddress)
-#define FMTRA "0x%016"PRIxPTR
 
 #endif /* (defined (MLTON_GC_INTERNAL_TYPES)) */
 

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -419,13 +419,14 @@ objptr GC_HH_forkThread(GC_state s, pointer threadp, pointer dp) {
     return BOGUS_OBJPTR;
   }
 
-#if ASSERT
   GC_returnAddress cont_ret = *((GC_returnAddress*)(pframe - GC_RETURNADDRESS_SIZE));
   GC_frameInfo fi = getFrameInfoFromReturnAddress(s, cont_ret);
+#if ASSERT
   assert(fi->kind == PCALL_CONT_FRAME);
+  assert(fi->pcallInfo != NULL);
 #endif
-  GC_returnAddress parl_ret = *((GC_returnAddress*)(pframe - 2 * GC_RETURNADDRESS_SIZE));
-  GC_returnAddress parr_ret = *((GC_returnAddress*)(pframe - 3 * GC_RETURNADDRESS_SIZE));
+  GC_returnAddress parl_ret = fi->pcallInfo->parl;
+  GC_returnAddress parr_ret = fi->pcallInfo->parr;
 
   // =========================================================================
   // First, write dp (data pointer) onto the promotable frame


### PR DESCRIPTION
As suggested by @JohnReppy, rather than storing the alternate return addresses of a `PCall` on the (dynamic) call stack, one can store them in a (static) table.  In MLton, we can store the alternate return addresses in the `struct GC_frameInfo` that corresponds to the `PCALL_CONT_FRAME`.
