### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -10,8 +10,8 @@
 # Specify C compiler and binutils.
 # Can be used for alternative tools (e.g., `CC=clang` or `CC=gcc-7`).
 CC := gcc
-AR := gcc-ar
-RANLIB := gcc-ranlib
+AR := ar
+RANLIB := ranlib
 STRIP := strip
 
 # Specify GMP include and library paths, if not on default search paths.

--- a/include/c-main.h
+++ b/include/c-main.h
@@ -13,6 +13,8 @@
 #include "common-main.h"
 #include "c-common.h"
 
+void Parallel_run (void);
+
 PRIVATE C_Pthread_Key_t gcstate_key;
 
 PRIVATE GC_state MLton_gcState() {
@@ -70,7 +72,7 @@ static void MLton_callFromC (CPointer localOpArgsResPtr) {              \
 }
 
 #define MLtonThreadFunc(ml)                                             \
-void MLton_threadFunc (void* arg) {                                     \
+void *MLton_threadFunc (void* arg) {                                    \
   uintptr_t nextBlock;                                                  \
   GC_state s = (GC_state)arg;                                           \
                                                                         \
@@ -116,7 +118,7 @@ void MLton_threadFunc (void* arg) {                                     \
     /*printf("[%d] calling Parallel_run\n", s->procNumber);*/           \
     Parallel_run ();                                                    \
   }                                                                     \
-  return 1;                                                             \
+  return (void *)1;                                                     \
 }
 
 #define MLtonMain(al, mg, mfs, mmc, pk, ps, ml)                         \

--- a/runtime/gc/done.c
+++ b/runtime/gc/done.c
@@ -82,7 +82,11 @@ static void displayCumulativeStatistics (FILE *out, struct GC_cumulativeStatisti
   uintmax_t critTime;
   uintmax_t bspTime;
 
+#ifdef __MACH__
+  getrusage_thread (&ru_total);
+#else
   getrusage (RUSAGE_THREAD, &ru_total);
+#endif
   totalTime = rusageTime (&ru_total);
   gcTime = rusageTime (&cumulativeStatistics->ru_gc);
   syncTime = rusageTime (&cumulativeStatistics->ru_sync);
@@ -166,7 +170,11 @@ static void displayCumulativeStatisticsJSON (FILE *out, GC_state s) {
   struct rusage ru_total;
   uintmax_t totalTime;
 
+#ifdef __MACH__
+  getrusage_thread (&ru_total);
+#else
   getrusage (RUSAGE_THREAD, &ru_total);
+#endif
   totalTime = rusageTime (&ru_total);
 
   fprintf(out, "{ ");

--- a/runtime/gc/getrusage_thread.h
+++ b/runtime/gc/getrusage_thread.h
@@ -1,0 +1,27 @@
+#ifdef __MACH__
+
+#include <errno.h>
+#include <mach/mach.h>
+#include <sys/resource.h>
+
+static inline int getrusage_thread(struct rusage *rusage) {
+  thread_basic_info_data_t info;
+  mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+
+  mach_port_t thread = mach_thread_self();
+  kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+  mach_port_deallocate(mach_task_self(), thread);
+
+  if (kr == KERN_SUCCESS && (info.flags & TH_FLAGS_IDLE) == 0) {
+    memset(rusage, 0, sizeof(struct rusage));
+    rusage->ru_utime.tv_sec = info.user_time.seconds;
+    rusage->ru_utime.tv_usec = info.user_time.microseconds;
+    rusage->ru_stime.tv_sec = info.system_time.seconds;
+    rusage->ru_stime.tv_usec = info.system_time.microseconds;
+    return 0;
+  } else {
+    errno = EINVAL;
+    return -1;
+  }
+}
+#endif

--- a/runtime/gc/handler.h
+++ b/runtime/gc/handler.h
@@ -11,11 +11,11 @@
 
 static inline void switchToSignalHandlerThreadIfNonAtomicAndSignalPending (GC_state s);
 
-void relayerLoop(GC_state s);
-
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */
 
 #if (defined (MLTON_GC_INTERNAL_BASIS))
+
+void relayerLoop(GC_state s);
 
 PRIVATE void GC_startSignalHandler (GC_state s);
 PRIVATE void GC_finishSignalHandler (GC_state s);

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -449,7 +449,7 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
 
   if (needGCTime(s))
   {
-    startTiming(RUSAGE_THREAD, &ru_start);
+    startTiming(&ru_start);
   }
 
   timespec_now(&startTime);
@@ -995,13 +995,13 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
   {
     if (detailedGCTime(s))
     {
-      stopTiming(RUSAGE_THREAD, &ru_start, &s->cumulativeStatistics->ru_gcHHLocal);
+      stopTiming(&ru_start, &s->cumulativeStatistics->ru_gcHHLocal);
     }
     /*
      * RAM_NOTE: small extra here since I recompute delta, but probably not a
      * big deal...
      */
-    stopTiming(RUSAGE_THREAD, &ru_start, &s->cumulativeStatistics->ru_gc);
+    stopTiming(&ru_start, &s->cumulativeStatistics->ru_gc);
   }
 
   Trace0(EVENT_LGC_LEAVE);

--- a/runtime/gc/hierarchical-heap-ebr.h
+++ b/runtime/gc/hierarchical-heap-ebr.h
@@ -10,14 +10,14 @@
 #ifndef HIERARCHICAL_HEAP_EBR_H_
 #define HIERARCHICAL_HEAP_EBR_H_
 
-#if (defined (MLTON_GC_INTERNAL_FUNCS))
+#if (defined (MLTON_GC_INTERNAL_BASIS))
 
 void HH_EBR_init(GC_state s);
 void HH_EBR_enterQuiescentState(GC_state s);
 void HH_EBR_leaveQuiescentState(GC_state s);
 void HH_EBR_retire(GC_state s, HM_UnionFindNode hhuf);
 
-#endif // MLTON_GC_INTERNAL_FUNCS
+#endif // MLTON_GC_INTERNAL_BASIS
 
 
 #endif // HIERARCHICAL_HEAP_EBR_H_

--- a/runtime/gc/processor.h
+++ b/runtime/gc/processor.h
@@ -3,7 +3,7 @@
 #ifndef PROCESSOR_H_
 #define PROCESSOR_H_
 
-#if (defined (MLTON_GC_INTERNAL_FUNCS))
+#if (defined (MLTON_GC_INTERNAL_BASIS))
 /*************/
 /* Interface */
 /*************/
@@ -15,6 +15,6 @@ void Proc_waitForInitialization (GC_state s);
 void Proc_signalInitialization (GC_state s);
 bool Proc_isInitialized (GC_state s);
 
-#endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */
+#endif /* (defined (MLTON_GC_INTERNAL_BASIS)) */
 
 #endif /* PROCESSOR_H_ */

--- a/runtime/gc/rusage.c
+++ b/runtime/gc/rusage.c
@@ -88,15 +88,15 @@ uintmax_t rusageTime (struct rusage *ru) {
   return result;
 }
 
-void startTiming (int who, struct rusage *ru_start) {
-  getrusage (who, ru_start);
+void startTiming (struct rusage *ru_start) {
+  getrusage_thread (ru_start);
 }
 
 /* Accumulate and return time as number of milliseconds. */
-uintmax_t stopTiming (int who, struct rusage *ru_start, struct rusage *ru_acc) {
+uintmax_t stopTiming (struct rusage *ru_start, struct rusage *ru_acc) {
   struct rusage ru_finish, ru_total;
 
-  getrusage (who, &ru_finish);
+  getrusage_thread (&ru_finish);
   rusageMinusMax (&ru_finish, ru_start, &ru_total);
   rusagePlusMax (ru_acc, &ru_total, ru_acc);
   return rusageTime (&ru_total);

--- a/runtime/gc/rusage.h
+++ b/runtime/gc/rusage.h
@@ -19,8 +19,8 @@ static inline void rusageMultiply (struct rusage *ru1,
                                    size_t factor,
                                    struct rusage *ru);
 static inline uintmax_t rusageTime (struct rusage *ru);
-static inline void startTiming (int who, struct rusage *ru_start);
-static uintmax_t stopTiming (int who, struct rusage *ru_start, struct rusage *ru_gc);
+static inline void startTiming (struct rusage *ru_start);
+static uintmax_t stopTiming (struct rusage *ru_start, struct rusage *ru_gc);
 
 void timespec_now(struct timespec *x);
 /* compute dst = dst - x. requires that dst >= x. */

--- a/runtime/gc/switch-thread.c
+++ b/runtime/gc/switch-thread.c
@@ -18,7 +18,7 @@ void switchToThread(GC_state s, objptr op) {
      * termination checks happen rarely, and reset terminateCheckCounter to 0
      * when they do. */
     GC_MayTerminateThreadRarely(s, &terminateCheckCounter);
-    if (terminateCheckCounter == 0) pthread_yield();
+    if (terminateCheckCounter == 0) sched_yield();
     // Sanity check: don't get deadlocked by self
     assert(otherProcNum != s->procNumber);
     otherProcNum = atomicLoadS32(&(thread->currentProcNum));

--- a/runtime/gc/termination.c
+++ b/runtime/gc/termination.c
@@ -26,7 +26,7 @@ void GC_TerminateThread(GC_state s) {
   while (TRUE) {
     uint32_t status = atomicLoadU32(statusp);
     while (status != 1) {
-      pthread_yield();
+      sched_yield();
       status = atomicLoadU32(statusp);
     }
     bool success = __sync_bool_compare_and_swap(statusp, 1, 0);

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -92,7 +92,7 @@ void GC_HH_mergeThreads(pointer threadp, pointer childp) {
      * termination checks happen rarely, and reset terminateCheckCounter to 0
      * when they do. */
     GC_MayTerminateThreadRarely(s, &terminateCheckCounter);
-    if (terminateCheckCounter == 0) pthread_yield();
+    if (terminateCheckCounter == 0) sched_yield();
   }
 
 #if ASSERT
@@ -312,7 +312,7 @@ void GC_HH_joinIntoParent(
      * termination checks happen rarely, and reset terminateCheckCounter to 0
      * when they do. */
     GC_MayTerminateThreadRarely(s, &terminateCheckCounter);
-    if (terminateCheckCounter == 0) pthread_yield();
+    if (terminateCheckCounter == 0) sched_yield();
   }
 
 #if ASSERT

--- a/runtime/platform/darwin.c
+++ b/runtime/platform/darwin.c
@@ -2,6 +2,9 @@
 
 #include <dlfcn.h>
 #include <stdio.h>
+#include <errno.h>
+#include <mach/mach.h>
+#include <sys/resource.h>
 
 #include "platform/diskBack.unix.c"
 #include "platform/mmap-protect.c"
@@ -14,4 +17,25 @@ void GC_displayMem (void) {
 
         snprintf (buffer, cardof(buffer), "/usr/bin/vmmap -w -interleaved %d\n", (int)getpid ());
         (void)system (buffer);
+}
+
+int getrusage_thread(struct rusage *rusage) {
+        thread_basic_info_data_t info;
+        mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+
+        mach_port_t thread = mach_thread_self();
+        kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+        mach_port_deallocate(mach_task_self(), thread);
+
+        if (kr == KERN_SUCCESS && (info.flags & TH_FLAGS_IDLE) == 0) {
+        memset(rusage, 0, sizeof(struct rusage));
+        rusage->ru_utime.tv_sec = info.user_time.seconds;
+        rusage->ru_utime.tv_usec = info.user_time.microseconds;
+        rusage->ru_stime.tv_sec = info.system_time.seconds;
+        rusage->ru_stime.tv_usec = info.system_time.microseconds;
+        return 0;
+        } else {
+        errno = EINVAL;
+        return -1;
+        }
 }

--- a/runtime/platform/darwin.h
+++ b/runtime/platform/darwin.h
@@ -51,3 +51,5 @@
 
 /* for Posix_ProcEnv_environ */
 #define environ *_NSGetEnviron()
+
+int getrusage_thread(struct rusage *rusage);

--- a/runtime/platform/linux.h
+++ b/runtime/platform/linux.h
@@ -121,3 +121,8 @@ static inline void set_cpu_affinity(int cpu) {
   if ((errno = pthread_setaffinity_np(thread, sizeof cpuset, &cpuset)) != 0)
     perror("Could not set affinity");
 }
+
+static inline int getrusage_thread(struct rusage *rusage) {
+        getrusage(RUSAGE_THREAD, rusage);
+}
+


### PR DESCRIPTION
I followed the instructions in #181.
The required `rand48_r` series functions were re-implemented as it is a GNU extension and Linux-only.
The call to `getrusage(RUSAGE_THREAD, ...)` is also replaced on this platform.