### PR TITLE
Avoid closure alloc on `par` fast path, fix broken token invariants, and fix subtle GC bug in `GC_HH_forkThread`

### DIFF
--- a/basis-library/schedulers/par-pcall/MkScheduler.sml
+++ b/basis-library/schedulers/par-pcall/MkScheduler.sml
@@ -839,6 +839,12 @@ struct
 
     fun heartbeatHandler (thread: Thread.t) =
       let
+        (* NOTE: we can't assert the token invariants here! We can only do
+         * so after the heartbeatHandler finishes. It's possible for the
+         * token invariants to be briefly violated, in which case the
+         * handler restores them.
+         *)
+
         val hadEnoughToSpawnBefore =
           (currentSpareHeartbeatTokens () >= spawnCost)
 
@@ -853,13 +859,17 @@ struct
           else
             i
 
-        val numSpawned =
-          if hadEnoughToSpawnBefore then
-            (incrementNumSkippedHeartbeats (); 0)
-          else
-            loop 0
+        val numSpawned = loop 0
 
         val _ = assertTokenInvariants thread "heartbeatHandler"
+        val _ =
+          (* If the hearbeat handler intervenes immediately before the eager
+           * check at each `par`, then there should be exactly one spawn.
+           *)
+          if hadEnoughToSpawnBefore andalso numSpawned > 1 then
+            die (fn _ => "scheduler bug: more than one eager fork was missed")
+          else
+            ()
       in
         incrementNumHeartbeats ()
       end

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -104,7 +104,7 @@ signature PRIM =
        | MLton_size (* to rssa (as runtime C fn) *)
        | MLton_touch (* to rssa (as nop) or backend (as nop) *)
        | PCall (* closure convert *)
-       | PCall_forkThreadAndSetData (* to rssa (as runtime C fn) *)
+       | PCall_forkThreadAndSetData of {youngest: bool} (* to rssa (as runtime C fn) *)
        | PCall_getData (* backend *)
        | Real_Math_acos of RealSize.t (* codegen *)
        | Real_Math_asin of RealSize.t (* codegen *)

--- a/mlton/closure-convert/abstract-value.fun
+++ b/mlton/closure-convert/abstract-value.fun
@@ -505,7 +505,7 @@ fun primApply {prim: Type.t Prim.t, args: t vector, resultTy: Type.t}: t =
             in coerce {from = arg, to = serialValue (ty arg)}
                ; result ()
             end
-       | Prim.PCall_forkThreadAndSetData =>
+       | Prim.PCall_forkThreadAndSetData _ =>
             let val (_, arg) = twoArgs ()
             in coerce {from = arg, to = pcallDataValue (ty arg)}
                ; result ()

--- a/mlton/closure-convert/closure-convert.fun
+++ b/mlton/closure-convert/closure-convert.fun
@@ -1199,7 +1199,7 @@ fun closureConvert
                                          v1 (coerce (convertVarInfo y,
                                                      VarInfo.value y, v)))
                              end
-                        | Prim.PCall_forkThreadAndSetData =>
+                        | Prim.PCall_forkThreadAndSetData _ =>
                              let
                                 val t = varExpInfo (arg 0)
                                 val x = varExpInfo (arg 1)

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -1371,7 +1371,7 @@ fun transform (program: Program.t): Program.t =
                 | Prim.Array_toArray => arrayToArray (arg 0)
                 | Prim.Array_toVector => arrayToVector (arg 0)
                 | Prim.Array_update _ => sequenceUpd arraySequence
-                | Prim.PCall_forkThreadAndSetData =>
+                | Prim.PCall_forkThreadAndSetData _ =>
                      let
                         val x = arg 1
                      in

--- a/mlton/ssa/deep-flatten.fun
+++ b/mlton/ssa/deep-flatten.fun
@@ -766,7 +766,7 @@ fun transform2 (program as Program.T {datatypes, functions, globals, main}) =
              | Prim.MLton_equal => equal ()
              | Prim.MLton_size => dontFlatten ()
              | Prim.MLton_share => dontFlatten ()
-             | Prim.PCall_forkThreadAndSetData =>
+             | Prim.PCall_forkThreadAndSetData _ =>
                   let
                      val x = Vector.sub (args, 1)
                      val _ = Value.dontFlatten x

--- a/mlton/ssa/split-types.fun
+++ b/mlton/ssa/split-types.fun
@@ -189,7 +189,7 @@ fun transform (program as Program.T {datatypes, globals, functions, main}) =
                | Prim.Array_toArray => Vector.sub (args, 0)
                | Prim.Array_toVector => Vector.sub (args, 0)
                | Prim.Array_update _ => updatePrim TypeInfo.Array args
-               | Prim.PCall_forkThreadAndSetData =>
+               | Prim.PCall_forkThreadAndSetData _ =>
                   let
                      val ty = Vector.first targs
                      val x = Vector.sub (args, 1)

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -83,6 +83,7 @@ struct GC_state {
                                           * signal handler (the thread that
                                           * was interrupted)
                                           */
+  objptr savedAdditionalRoot; /* additional root for GC, if needed */
   int (*saveGlobals)(FILE *f); /* saves the globals to the file. */
   bool saveWorldStatus; /* */
   objptr signalHandlerThread; /* Handler for signals (in heap). */

--- a/runtime/gc/hierarchical-heap-collection.c
+++ b/runtime/gc/hierarchical-heap-collection.c
@@ -568,6 +568,15 @@ void HM_HHC_collectLocal(uint32_t desiredScope)
     );
   }
 
+  if (s->savedAdditionalRoot != BOGUS_OBJPTR) {
+    forwardHHObjptr(
+      s,
+      &(s->savedAdditionalRoot),
+      s->savedAdditionalRoot,
+      &forwardHHObjptrArgs
+    );
+  }
+
   /* ======================================================================= */
 
   /* forward contents of deque, only for the range of the deque that is

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -592,6 +592,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->rootsLength = 0;
   s->savedThread = BOGUS_OBJPTR;
   s->savedThreadDuringSignalHandler = BOGUS_OBJPTR;
+  s->savedAdditionalRoot = BOGUS_OBJPTR;
 
   initFixedSizeAllocator(getHHAllocator(s), sizeof(struct HM_HierarchicalHeap), BLOCK_FOR_HH_ALLOCATOR);
   initFixedSizeAllocator(getUFAllocator(s), sizeof(struct HM_UnionFindNode), BLOCK_FOR_UF_ALLOCATOR);
@@ -745,6 +746,7 @@ void GC_duplicate (GC_state d, GC_state s) {
   d->rootsLength = 0;
   d->savedThread = BOGUS_OBJPTR;
   d->savedThreadDuringSignalHandler = BOGUS_OBJPTR;
+  d->savedAdditionalRoot = BOGUS_OBJPTR;
   d->signalHandlerThread = BOGUS_OBJPTR;
   d->signalsInfo.amInSignalHandler = FALSE;
   d->signalsInfo.gcSignalHandled = FALSE;

--- a/runtime/gc/stack.c
+++ b/runtime/gc/stack.c
@@ -247,7 +247,7 @@ void copyStackFrameToNewStack (
 
   GC_returnAddress ret = *((GC_returnAddress*)(frame - GC_RETURNADDRESS_SIZE));
   GC_frameInfo fi = getFrameInfoFromReturnAddress(s, ret);
-  assert(fi->kind == PCALL_PARL_FRAME);
+  assert(fi->kind == PCALL_CONT_FRAME);
   pointer frameBottom = frame - fi->size;
   GC_memcpy(frameBottom, getStackBottom(s, to), fi->size);
   to->used = fi->size;

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -125,7 +125,10 @@ PRIVATE void GC_HH_setMinLocalCollectionDepth(pointer thread, Word32 depth);
 // forkThread should only be called if canForkThread returns true
 // (and without resuming the thread in between)
 PRIVATE bool GC_HH_canForkThread(GC_state s, pointer thread);
-PRIVATE objptr GC_HH_forkThread(GC_state s, pointer thread, pointer jp);
+
+// If youngest, then pick the youngest promotable frame. This is used in
+// the scheduler for an optimization in a special case.
+PRIVATE objptr GC_HH_forkThread(GC_state s, bool youngest, pointer thread, pointer jp);
 
 /* Moves a "new" thread to the appropriate depth, before we switch to it.
  * This essentially puts the thread (and its stack) into the hierarchy.


### PR DESCRIPTION
This patch attempts a different approach for handling the eager forking optimization, approximately along these lines:

```sml
fun par(f, g) =
  let
    fun f'() =
      ( if currentSpareHeartbeatTokens() = 0 then
          ()
        else
          ( Thread.atomicBegin()
          ; if currentSpareHeartbeatTokens() >= 1 then
              tryPromoteNow()
            else
              ()
          ; Thread.atomicEnd()
          )

      ; f()
      )
  in
    pcallFork(f', g)
  end
```

The idea here is to do the `pcall` unconditionally, and then (after entry into the callee) check whether or not we can trigger a promotion eagerly. If we can, then due to the token invariants, there's only one possible frame which could be promoted (the immediate ancestor). 

To make this as fast as possible, I implemented an optimization within `GC_HH_forkThread` to promote the *youngest promotable frame*. This optimization is only valid at `tryPromoteNow()`, where we know that *the youngest frame IS the oldest frame*. (This is asserted in the runtime system, so it will be checked automatically on debug builds.) Implementing this optimization required updating the `PCall_forkThreadAndSetData` to keep track of whether or not the optimization should be used. I added another prim `PCall_forkThreadAndSetData_youngest` which immediately elaborates into the generalized prim.

The `tryPromoteNow()` above is a bit abstracted from the actual implementation. The idea is to try to trigger a promotion, and silently back out if no ancestor is promotable. And, it turns out the latter behavior is possible, due to concurrency with the heartbeat handler: if a heartbeat arrives immediately after the `currentSpareHeartbeatTokens() = 0` check, this could go ahead and promote before we get to `tryPromoteNow()`, in which case the call to `tryPromoteNow()` will silently fail, with no harm, and the execution continues safely.

In other words, this implementation upholds the token invariants, regardless of concurrency with heartbeat handling. It therefore fixes #194.

## More efficient compilation, too
A secondary benefit of this implementation is that it results in more efficient compilation along the fast path. This implementation of `par` allows for both of the `f` and `g` closures to be eliminated, resulting in fewer heap allocations along the fast path.

To see this, consider a simple parallel fib:
```sml
fun fib (n: Word64.word) =
  if n < 0w2 then n else
  let val (x, y) = ForkJoin.par (fn _ => fib (n - 0w1), fn _ => fib (n - 0w2))
  in x + y
  end
```

**Prior to this patch**, MPL generates the following RSSA-level function:
```
fun fib_0 (x_3609: Word64, env_8: Objptr (opt_48)): ... = L_1639 ()
  ...
  L_1639 () Jump =
    x_3611: Objptr (opt_47) = OP (env_8, 8): Objptr (opt_47)
    x_3610: Word32 = WordU64_lt (x_3609, global_28)
    switch {test = x_3610,
            default = None,
            expect = None,
            cases = ((0x0:w32, L_5062), (0x1:w32, L_5063))}
  L_5062 () Jump =
    L_1640 ()
  L_5063 () Jump =
    L_1641 ()
  L_1641 () Jump =
    return (x_3609)
  L_1640 () Jump =
    x_8026: Word64 = x_3609
    x_8025: Objptr (opt_48) = env_8
    x_3614: Objptr (opt_49)
      = NormalObject {init = ({offset = 0, src = x_8026},
                              {offset = 8, src = x_8025}),
                      tycon = opt_49}
    x_3613: Word32 = SpareHeartbeatTokens
    x_3612: Word32 = WordU32_lt (x_3613, global_18)
    switch {test = x_3612,
            default = None,
            expect = None,
            cases = ((0x0:w32, L_5060), (0x1:w32, L_5061))}
  L_1643 () Jump =
    PCall leftSide_1 (x_3609, env_8) {cont = L_5058,
                                      parl = L_5059,
                                      parr = L_5057}
  ...
```

Here, we see that before we get to the PCall, there is one `NormalObject` allocation; this is a closure for the right-hand side of the call to `ForkJoin.par`, which is used only along the eager forking path ([here](https://github.com/MPLLang/mpl/blob/b7629b4e12e6752130ac100c1b9a8a2b199ba786/basis-library/schedulers/par-pcall/MkScheduler.sml#L1108)); in particular, this closure is pushed onto the scheduler queue.

**With this patch**, MPL now generates this RSSA function:
```
fun fib_0 (x_3765: Word64, env_8: Objptr (opt_63)): ... = L_1721 ()
  ...
  L_1721 () Jump = 
    x_3766: Word32 = WordU64_lt (x_3765, global_28)
    switch {test = x_3766,
            default = None,
            expect = None,
            cases = ((0x0:w32, L_4937), (0x1:w32, L_4938))}
  L_4937 () Jump = 
    L_1722 ()
  L_4938 () Jump = 
    L_1723 ()
  L_1723 () Jump = 
    return (x_3765)
  L_1722 () Jump = 
    PCall leftSide_1 (env_8, x_3765) {cont = L_4935,
                                      parl = L_4936,
                                      parr = L_4934}
  ...
```

We can see that this closure allocation has been eliminated. The performance advantage on a single core is significant: approximately 30%.
```
# ========= BEFORE ===========
$ bin/fib @mpl procs 1 -- -N 40
fib 40
finished in 2.2737s
result 102334155
$ bin/fib @mpl procs 8 set-affinity -- -N 40
fib 40
finished in 0.3574s
result 102334155

# ========= AFTER ===========
$ bin/fib @mpl procs 1 -- -N 40
fib 40
finished in 1.7898s
result 102334155
$ bin/fib @mpl procs 8 set-affinity -- -N 40
fib 40
finished in 0.2687s
result 102334155
```

Before I merge this, I need to do more performance testing. IIRC, this patch may have negative impact on benchmarks that are span-limited on high core counts, in particular because the raw cost of eager forking cost under this approach is more expensive than it was previously. We will see.