### PR TITLE
Fix `BounceVars` handling of `SporkSpwn` and `SpoinSync` blocks

### DIFF
--- a/mlton/backend/bounce-vars.fun
+++ b/mlton/backend/bounce-vars.fun
@@ -36,6 +36,7 @@ fun shouldAvoid (Block.T {kind, ...}) =
     * going over a bad edge *)
    case kind of
         Kind.Jump => true
+      | Kind.SpoinSync _ => true
       | _ => false
 
 fun shouldBounceAt (Block.T {kind, ...}) =
@@ -44,9 +45,11 @@ fun shouldBounceAt (Block.T {kind, ...}) =
     * which variables go to the stack,
     * and similarly to above,
     * cannot be frivolously changed *)
-   case Kind.frameStyle kind of
-        Kind.OffsetsAndSize => true
-      | _ => false
+   case kind of
+      Kind.Cont _ => true
+    | Kind.CReturn {func, ...} => CFunction.mayGC func
+    | Kind.Handler => true
+    | _ => false
 
 structure Weight = struct
 
@@ -130,7 +133,7 @@ fun transform p =
 
             val {get=labelInfo, ...} = Property.get
                (Label.plist, Property.initFun
-                  (fn _ => {inLoop=ref NotInLoop, block=ref NONE}))
+                  (fn l => {inLoop=ref NotInLoop, block=ref NONE, alt=Label.new l}))
 
             val numRewritten = ref 0
             fun setRewrite (v, weight) =
@@ -336,8 +339,13 @@ fun transform p =
 
             fun insertRewriteBlock (destLabel, direction) =
                let
-                  val {block, ...} = labelInfo destLabel
-                  val Block.T {label=destLabel, args=destArgs, ...} = (valOf o !) block
+                  val {block, alt, ...} = labelInfo destLabel
+                  val Block.T {label=destLabel, kind=destKind, args=destArgs, ...} = (valOf o !) block
+                  val tgtLabel =
+                     case destKind of
+                        Kind.SporkSpwn _ => alt
+                      | Kind.SpoinSync _ => alt
+                      | _ => destLabel
 
                   val args = Vector.map (destArgs, fn (v, ty) => (Var.new v, ty))
                   val live = beginNoFormals destLabel
@@ -372,15 +380,10 @@ fun transform p =
                                pinned=true,
                                src=src}
                         end)
-                  (* Due to the loop forest construction, (i.e. shouldAvoid)
-                   * The kind of a block on the edge is always Kind.Jump
-                   * since every non-Jump must be followed by a case
-                   * transfer to exit the loop conditionally. *)
-                  val kind = Kind.Jump
                   val label = Label.new destLabel
                   val jumpArgs = Vector.map (args, fn (v, ty) => Operand.Var {var=v, ty=ty})
-                  val transfer = Transfer.Goto {dst=destLabel, args=jumpArgs}
-                  val block = Block.T {args=args, kind=kind, label=label, statements=statements, transfer=transfer}
+                  val transfer = Transfer.Goto {dst=tgtLabel, args=jumpArgs}
+                  val block = Block.T {args=args, kind=destKind, label=label, statements=statements, transfer=transfer}
                   val _ = List.push (newBlocks, block)
                in
                   label
@@ -388,7 +391,7 @@ fun transform p =
 
             fun handleBlock (b as Block.T {args, kind, label, statements, transfer}) =
                let
-                  val {inLoop, ...} = labelInfo label
+                  val {inLoop, alt, ...} = labelInfo label
                   val inLoop = !inLoop
                   fun test l =
                      let
@@ -400,18 +403,37 @@ fun transform p =
                            | (InLoop _, NotInLoop) => SOME LeaveLoop
                            | _ => NONE
                      end
-                  val needsRewrite = ref false
                   fun rewrite destLabel =
                      case test destLabel of
                           NONE => destLabel
-                        | SOME dir =>
-                             ( needsRewrite := true ;
-                               insertRewriteBlock (destLabel, dir))
+                        | SOME dir => insertRewriteBlock (destLabel, dir)
                   val newTransfer = Transfer.replaceLabels(transfer, rewrite)
+                  fun split () =
+                     let
+                        val _ =
+                           List.push (newBlocks, Block.T {args = args,
+                                                          kind = Kind.Jump,
+                                                          label = alt,
+                                                          statements = statements,
+                                                          transfer = newTransfer})
+                        val newArgs = Vector.map (args, fn (x, ty) => (Var.new x, ty))
+                     in
+                        Block.T {args = newArgs,
+                                 kind = kind,
+                                 label = label,
+                                 statements = Vector.new0 (),
+                                 transfer = Transfer.Goto {args = Vector.map (newArgs, fn (x, ty) => Operand.Var {ty = ty, var = x}),
+                                                           dst = alt}}
+                     end
                in
-                  if !needsRewrite
-                     then Block.T {args=args, kind=kind, label=label, statements=statements, transfer=newTransfer}
-                     else b
+                  case kind of
+                     Kind.SporkSpwn _ => split ()
+                   | Kind.SpoinSync _ => split ()
+                   | _ => Block.T {args = args,
+                                   kind = kind,
+                                   label = label,
+                                   statements = statements,
+                                   transfer = transfer}
                end
             val _ = Vector.foreach (blocks, fn b => List.push (newBlocks, handleBlock b))
             val newBlocks = Vector.fromListRev (!newBlocks)


### PR DESCRIPTION
The `BounceVars` RSSA pass assumed that any block that was rewritten to accommodate bounced vars was `Kind.Jump`, but this is not true on the `spork` branch, because a `SpoinSync` is `Jump`-like but a distinct kind.

Closes #199