### PR TITLE
Fix `Backend` handling of nested `Spork`s

### DIFF
--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -925,8 +925,12 @@ fun toMachine (rssa: Rssa.Program.t) =
                    val (inSpwn, resetInSpwn) =
                       case kind of
                          R.Kind.SporkSpwn _ =>
-                            (inSpwn := true
-                             ; (true, fn () => inSpwn := false))
+                            let
+                               val oldInSpwn = !inSpwn
+                               val _ = inSpwn := true
+                            in
+                               (true, fn () => inSpwn := oldInSpwn)
+                            end
                        | _ => (!inSpwn, fn () => ())
                    val _ = setLabelInfo (label, {args = args, inSpwn = inSpwn})
                    val _ = newVarInfos args


### PR DESCRIPTION
In the Machine IR, each block is annotated with `raises: Live.t vector option` and `returns: Live.t vector option` that indicate whether or not the function can return/raise after reaching this block and the live operands that will be returned/raised (should be `StackOffset`s).

Control down a `SporkSpwn` should never return or raise, so the translation from RSSA to Machine performs a DFS to find each block reachable from a `SporkSpwn` and tag them as `inSpwn`, so that the block is translated as `raises = NONE` and `returns = NONE`.

However, the `inSpwn` tagging was not correct for nested `Spork`s.  Leaving the DFS from one `SporkSpwn` should not reset the `inSpwn` tag to `false`; it should reset the `inSpwn` tag to the previous value.

Closes #201