### PR TITLE
multi stream on GPU fix

### DIFF
--- a/basis-library/schedulers/hybrid/FORK_JOIN.sig
+++ b/basis-library/schedulers/hybrid/FORK_JOIN.sig
@@ -3,7 +3,7 @@ sig
   val par: (unit -> 'a) * (unit -> 'b) -> 'a * 'b
   val parfor: int -> int * int -> (int -> unit) -> unit
 
-  val choice: {prefer_cpu: unit -> 'a, prefer_gpu: string -> 'a} -> 'a
+  val choice: {prefer_cpu: unit -> 'a, prefer_gpu: int -> 'a} -> 'a
 
   val alloc: int -> 'a array
 

--- a/basis-library/schedulers/hybrid/Scheduler.sml
+++ b/basis-library/schedulers/hybrid/Scheduler.sml
@@ -973,7 +973,7 @@ struct
               (* val _ = dbgmsg (fn _ => "choice: gpu after send") *)
 
               val _ = markDeviceIdxInUse deviceIdx
-              val result = doGpuTask gpuTask (Array.sub (devices, deviceIdx))
+              val result = doGpuTask gpuTask (Int.toString deviceIdx)
               val _ = reacquireDeviceIdx deviceIdx
 
               (* after finishing gpu task, we expect to run CPU code again, so try to

--- a/basis-library/schedulers/hybrid/Scheduler.sml
+++ b/basis-library/schedulers/hybrid/Scheduler.sml
@@ -973,7 +973,7 @@ struct
               (* val _ = dbgmsg (fn _ => "choice: gpu after send") *)
 
               val _ = markDeviceIdxInUse deviceIdx
-              val result = doGpuTask gpuTask (Int.toString deviceIdx)
+              val result = doGpuTask gpuTask deviceIdx
               val _ = reacquireDeviceIdx deviceIdx
 
               (* after finishing gpu task, we expect to run CPU code again, so try to


### PR DESCRIPTION
Currently, the device identifier passed to the client code is the device number (unique identifier for the GPU). However, we need the unique identifier for the Futhark context / CUDA stream that is available. This requires passing over the index into the devices (in actuality, contexts) array.

This PR is one of 2 required for this fix. The second one aims to change how the device identifier is handled in client side code in the hybrid-bench repository.