### PR TITLE
Promotion stacks

### DIFF
--- a/mlton/backend/rep-type.fun
+++ b/mlton/backend/rep-type.fun
@@ -732,6 +732,8 @@ fun ofGCField (f: GCField.t): t =
        | StackBottom => cpointer ()
        | StackLimit => cpointer ()
        | StackTop => cpointer ()
+       | PromoStackTop => cpointer ()
+       | PromoStackBot => cpointer ()
    end
 
 fun castIsOk {from, to, tyconTy = _} =

--- a/mlton/backend/runtime.fun
+++ b/mlton/backend/runtime.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 2009,2016-2017,2019-2022 Matthew Fluet.
+(* Copyright (C) 2024 Sam Westrick.
+ * Copyright (C) 2009,2016-2017,2019-2022 Matthew Fluet.
  * Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -20,6 +21,8 @@ structure GCField =
        | Frontier
        | Limit
        | LimitPlusSlop
+       | PromoStackTop
+       | PromoStackBot
        | SignalIsPending
        | SpareHeartbeatTokens
        | StackBottom
@@ -40,6 +43,8 @@ structure GCField =
              | Frontier => make "frontier"
              | Limit => make "limit"
              | LimitPlusSlop => make "limitPlusSlop"
+             | PromoStackTop => make "promoStackTop"
+             | PromoStackBot => make "promoStackBot"
              | SignalIsPending => make "signalsInfo.signalIsPending"
              | SpareHeartbeatTokens => make "spareHeartbeatTokens"
              | StackBottom => make "stackBottom"
@@ -54,6 +59,8 @@ structure GCField =
           | Frontier => "Frontier"
           | Limit => "Limit"
           | LimitPlusSlop => "LimitPlusSlop"
+          | PromoStackTop => "PromoStackTop"
+          | PromoStackBot => "PromoStackBot"
           | SignalIsPending => "SignalIsPending"
           | SpareHeartbeatTokens => "SpareHeartbeatTokens"
           | StackBottom => "StackBottom"

--- a/mlton/backend/runtime.sig
+++ b/mlton/backend/runtime.sig
@@ -29,6 +29,8 @@ signature RUNTIME =
              | StackBottom
              | StackLimit (* Must have StackTop <= StackLimit *)
              | StackTop (* Points at the next available byte on the stack. *)
+             | PromoStackTop (* Points at the next available slot on the promotion stack *)
+             | PromoStackBot (* Points at the oldest entry of the promotion stack *)
 
             val layout: t -> Layout.t
             val offset: t -> Bytes.t (* Field offset in struct GC_state. *)

--- a/runtime/gc/enter_leave.c
+++ b/runtime/gc/enter_leave.c
@@ -18,6 +18,7 @@ void enter (GC_state s) {
   GC_MayTerminateThread(s);
   /* used needs to be set because the mutator has changed s->stackTop. */
   getStackCurrent(s)->used = sizeofGCStateCurrentStackUsed (s);
+  setPromoStackOfCurrentThread(s, s->promoStackBot, s->promoStackTop);
   getThreadCurrent(s)->exnStack = s->exnStack;
   getThreadCurrent(s)->spareHeartbeatTokens = s->spareHeartbeatTokens;
   HM_HH_updateValues(getThreadCurrent(s), s->frontier);
@@ -36,11 +37,13 @@ void enter (GC_state s) {
 }
 
 void leave (GC_state s) {
+  s->spareHeartbeatTokens = getThreadCurrent(s)->spareHeartbeatTokens;
+  s->promoStackBot = getStackCurrent(s)->promoStackBot;
+
   /* The mutator frontier invariant may not hold
    * for functions that don't ensureBytesFree.
    */
   assert(invariantForMutator(s, FALSE, TRUE));
-  s->spareHeartbeatTokens = getThreadCurrent(s)->spareHeartbeatTokens;
   endAtomic (s);
   // Trace0(EVENT_RUNTIME_LEAVE);
 }

--- a/runtime/gc/foreach.c
+++ b/runtime/gc/foreach.c
@@ -96,7 +96,7 @@ void printObjectsInRange(GC_state s,
       p += alignWithExtra (s, dataBytes, GC_SEQUENCE_METADATA_SIZE);
     }
     else if (STACK_TAG == oi.tag) {
-      p += sizeof (struct GC_stack) + ((GC_stack)p)->reserved;
+      p += sizeof (struct GC_stack) + ((GC_stack)p)->reserved + ((GC_stack)p)->promoStackReserved;
     }
     else {
       fprintf(stderr, "cannot handle tag %u", oi.tag);
@@ -253,7 +253,7 @@ pointer foreachObjptrInObject (GC_state s, pointer p,
     assert(top == bottom);
 
  STACK_DONE:
-    p += sizeof (struct GC_stack) + stack->reserved;
+    p += sizeof (struct GC_stack) + stack->reserved + ((GC_stack)p)->promoStackReserved;;
   } else {
     assert (0 and "unknown object tag type");
   }

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -49,6 +49,8 @@ void setGCStateCurrentThreadAndStack (GC_state s) {
   s->stackBottom = getStackBottom (s, stack);
   s->stackTop = getStackTop (s, stack);
   s->stackLimit = getStackLimit (s, stack);
+  s->promoStackTop = stack->promoStackTop;
+  s->promoStackBot = stack->promoStackBot;
 }
 
 struct FixedSizeAllocator* getHHAllocator(GC_state s) {

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2012,2014,2019-2022 Matthew Fluet.
+/* Copyright (C) 2024 Sam Westrick.
+ * Copyright (C) 2012,2014,2019-2022 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -23,6 +24,8 @@ struct GC_state {
   volatile pointer stackTop; /* Top of stack in current thread. */
   pointer stackLimit; /* stackBottom + stackSize - maxFrameSize */
   ptrdiff_t exnStack;
+  pointer promoStackTop;
+  pointer promoStackBot;
   /* Alphabetized fields follow. */
   size_t alignment; /* */
   volatile bool amInGC;

--- a/runtime/gc/hierarchical-heap.c
+++ b/runtime/gc/hierarchical-heap.c
@@ -910,8 +910,9 @@ objptr copyStackOfThread(GC_state s, GC_thread thread) {
   GC_stack stackFrom = (GC_stack)objptrToPointer(thread->stack, NULL);
 
   size_t reserved = stackFrom->reserved;
+  size_t promoReserved = stackFrom->promoStackReserved;
   assert(isStackReservedAligned(s, reserved));
-  size_t stackSize = sizeofStackWithMetaData(s, reserved);
+  size_t stackSize = sizeofStackWithMetaData(s, reserved, promoReserved);
 
   HM_chunk newChunk = HM_allocateChunkWithPurpose(
     HM_HH_getChunkList(hh),
@@ -937,6 +938,7 @@ objptr copyStackOfThread(GC_state s, GC_thread thread) {
   *((GC_header*)frontier) = GC_STACK_HEADER;
   GC_stack stack = (GC_stack)(frontier + GC_HEADER_SIZE);
   stack->reserved = reserved;
+  stack->promoStackReserved = promoReserved;
   stack->used = 0;
   HM_updateChunkFrontierInList(
     HM_HH_getChunkList(hh),

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -17,7 +17,13 @@ size_t sizeofInitialBytesLive (GC_state s) {
 
   total = 0;
   total += s->staticHeaps.dynamic.size;
-  total += sizeofStackWithMetaData (s, sizeofStackInitialReserved (s)) + sizeofThread (s);
+  total +=
+    sizeofThread(s) +
+    sizeofStackWithMetaData(
+      s,
+      sizeofStackInitialReserved(s),
+      sizeofStackInitialPromoStackReserved(s)
+    );
   return total;
 }
 

--- a/runtime/gc/invariant.c
+++ b/runtime/gc/invariant.c
@@ -27,6 +27,9 @@ bool invariantForMutatorStack (GC_state s) {
   GC_stack stack = getStackCurrent(s);
   return (getStackTop (s, stack)
           <= getStackLimit (s, stack) + getStackTopFrameSize (s, stack))
+      && (getStackLimitPlusSlop(s, stack) <= stack->promoStackBot)
+      && (stack->promoStackBot <= stack->promoStackTop)
+      && (stack->promoStackTop <= getStackLimitPlusSlop(s, stack) + stack->promoStackReserved)
       && (FALSE == HM_getChunkOf((pointer)stack)->mightContainMultipleObjects);
 }
 

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -155,6 +155,8 @@ PRIVATE uint32_t GC_addSpareHeartbeats(GC_state s, uint32_t spares);
 PRIVATE void GC_HH_joinIntoParentBeforeFastClone(GC_state s, pointer threadp, uint32_t newDepth, uint64_t tidLeft, uint64_t tidRight);
 PRIVATE void GC_HH_joinIntoParent(GC_state s, pointer threadp, pointer rightSideThreadp, uint32_t newDepth, uint64_t tidLeft, uint64_t tidRight);
 
+PRIVATE void setPromoStackOfCurrentThread(GC_state s, pointer newBot, pointer newTop);
+
 #endif /* MLTON_GC_INTERNAL_BASIS */
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))

--- a/runtime/gen/gen-constants.c
+++ b/runtime/gen/gen-constants.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2016-2017,2020 Matthew Fluet.
+/* Copyright (C) 2024 Sam Westrick.
+ * Copyright (C) 2016-2017,2020 Matthew Fluet.
  * Copyright (C) 2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -62,6 +63,8 @@ int main (__attribute__ ((unused)) int argc,
   MkGCFieldOffset (frontier);
   MkGCFieldOffset (limit);
   MkGCFieldOffset (limitPlusSlop);
+  MkGCFieldOffset (promoStackTop);
+  MkGCFieldOffset (promoStackBot);
   MkGCFieldOffset (signalsInfo.signalIsPending);
   MkGCFieldOffset (spareHeartbeatTokens);
   MkGCFieldOffset (sourceMaps.curSourceSeqIndex);


### PR DESCRIPTION
This patch implements promotion stacks: an auxiliary data structure alongside every call-stack which keeps track of all of the promotable frames within that call-stack. This allows us, at each promotion, to find the oldest promotable frame in O(1) time. Previously, to find the oldest promotable frame, we had to walk the stack, costing O(#frames).

Promotion stacks are implemented using three additional values:
```c
  struct GC_stack {
    ...
    size_t promoStackReserved; // number of bytes reserved for the promotion stack
    pointer promoStackBot;
    pointer promoStackTop;
    ...
  }
```

These keep track of the bottom and top of the promotion stack, where each element of the promotion stack is a pointer to a promotable frame. The bottommost element is a pointer to the oldest promotable frame; the topmost element is the youngest. Stacks therefore have to be specially handled by LGC: whenever a stack is copied, we have to update the elements of the promo stack.

```
                      reserved bytes    promoStackReserved bytes
                            |                |
  ┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
  ┃ metadata ┃ struct ┃ frames        ┃ promo stack    ┃
  ┃          ┃        ┃               ┃  ....*....     ┃
  ┗━━━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━┃━━━━━━━━━┛
                          ↑              ↑   ┃    ↑
                          ┃              |   ┃    |
                          ┃   promoStackBot  ┃   promoStackTop
                          ┃                  ┃
                          ┗━━━━━━━━━━━━━━━━━━┛
                     (pointer to promotable frame)  
```

Note that promoStackTop is exclusive of the topmost element (i.e., the promo stack is empty whenever promoStackBot == promoStackTop).

These values are maintained in the compiled code as follows:
```
  At every PCall:
    *(pointer*)promoStackTop = StackTop
    promoStackTop += sizeof(pointer)
  At every seq (unpromoted) continuation:
    promoStackTop -= sizeof(pointer)
  At every sync (promoted) continuation:
    promoStackTop -= sizeof(pointer)
    promoStackBot = promoStackTop
  At promotion:
    oldestPromotableFrame = *(pointer*)promoStackBot;
    promoStackBot += sizeof(pointer)
    ... promote oldestPromotableFrame ...
```

This requires only a few extra instructions on the fast path. With this update, each PCall is slightly more expensive. The cost is very small: similar to passing just one extra argument on the call-stack at every PCall.