### PR TITLE
replace SML-level implementation of ABP deque with implementation in C

### DIFF
--- a/basis-library/schedulers/par-pcall/MkScheduler.sml
+++ b/basis-library/schedulers/par-pcall/MkScheduler.sml
@@ -410,10 +410,7 @@ struct
     let
       val {queue, ...} = vectorSub (workerLocalData, p)
     in
-      if not (Queue.pollHasWork queue) then
-        NONE
-      else
-        Queue.tryPopTop queue
+      Queue.tryPopTop queue
     end
 
   fun communicate () = ()
@@ -434,6 +431,7 @@ struct
       Queue.pushBot queue x
     end
 
+(*
   fun clear () =
     let
       val myId = myWorkerId ()
@@ -441,6 +439,7 @@ struct
     in
       Queue.clear queue
     end
+*)
 
   fun pop () =
     let
@@ -1143,7 +1142,7 @@ struct
             in
               case trySteal friend of
                 NONE => loop (tries+1)
-              | SOME (task, depth) => (task, depth)
+              | SOME task => task
             end
 
           val result = loop 0
@@ -1192,7 +1191,7 @@ struct
 
       fun acquireWork () : unit =
         let
-          val (task, depth) = stealLoop ()
+          val task = stealLoop ()
           val _ = incrementNumSteals ()
         in
           case task of

--- a/basis-library/schedulers/par-pcall/sources.mlb
+++ b/basis-library/schedulers/par-pcall/sources.mlb
@@ -23,7 +23,12 @@ local
   ../shh/CumulativePerProcTimer.sml
   ../shh/FORK_JOIN.sig
   ../shh/SimpleRandom.sml
-  ../shh/queue/DequeABP.sml
+  ann
+    "allowFFI true"
+    "allowPrim true"
+  in
+    ../shh/queue/DequeABP.sml
+  end
   (*Stack.sml*)
   ../shh/Result.sml
   ann

--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -46,6 +46,7 @@ extern C_Pthread_Key_t gcstate_key;
 
 #include "gc/gdtoa-multiple-threads-defs.c"
 
+#include "gc/abp-deque.c"
 #include "gc/assign.c"
 #include "gc/atomic.c"
 #include "gc/block-allocator.c"

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -92,6 +92,7 @@ typedef GC_state GCState_t;
 #include "gc/entanglement-suspects.h"
 #include "gc/local-scope.h"
 #include "gc/local-heap.h"
+#include "gc/abp-deque.h"
 #include "gc/assign.h"
 #include "gc/concurrent-list.h"
 #include "gc/remembered-set.h"

--- a/runtime/gc/abp-deque.c
+++ b/runtime/gc/abp-deque.c
@@ -1,0 +1,189 @@
+/* Copyright (C) 2024-2025 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+
+Bool ABP_deque_push_bot(
+  __attribute__ ((unused)) GC_state s,
+  __attribute__ ((unused)) objptr top_op,
+  objptr bot_op,
+  objptr data_op,
+  objptr elem_to_push_op)
+{
+  uint32_t* bot = (uint32_t*)objptrToPointer(bot_op, NULL);
+  objptr* data = (objptr*)objptrToPointer(data_op, NULL);
+
+  uint32_t local_bot = __atomic_load_n(bot, __ATOMIC_ACQUIRE);
+
+  if (local_bot == getSequenceLength(objptrToPointer(data_op, NULL))) {
+    return (Bool)FALSE;
+  }
+
+  __atomic_store_n(data + local_bot, elem_to_push_op, __ATOMIC_RELEASE);
+  __atomic_store_n(bot, local_bot+1, __ATOMIC_SEQ_CST);
+
+  return (Bool)TRUE;
+}
+
+
+/* This is a sanity check, we could leave it as an assertion but I'd rather
+ * see this error explicitly even in optimized builds. */
+static void
+ABP_deque_check_successful_pop(objptr result, objptr fail_value) {
+  if (result == fail_value) {
+    DIE("Scheduler bug: invalid pop in scheduler queue");
+  }
+}
+
+
+objptr ABP_deque_try_pop_bot(
+  __attribute__ ((unused)) GC_state s,
+  objptr top_op,
+  objptr bot_op,
+  objptr data_op,
+  objptr fail_value)
+{
+  uint64_t* top = (uint64_t*)objptrToPointer(top_op, NULL);
+  uint32_t* bot = (uint32_t*)objptrToPointer(bot_op, NULL);
+  objptr* data = (objptr*)objptrToPointer(data_op, NULL);
+
+  uint32_t local_bot = __atomic_load_n(bot, __ATOMIC_ACQUIRE);
+  if (local_bot == 0) {
+    return fail_value;
+  }
+
+  local_bot--;
+  __atomic_store_n(bot, local_bot, __ATOMIC_RELEASE);
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  objptr elem = __atomic_load_n(data + local_bot, __ATOMIC_ACQUIRE);
+  uint64_t local_top = __atomic_load_n(top, __ATOMIC_ACQUIRE);
+  uint32_t local_top_idx = UNPACK_IDX(local_top);
+
+  if (local_bot > local_top_idx) {
+    ABP_deque_check_successful_pop(elem, fail_value);
+    return elem;
+  }
+
+  // If local_bot <= local_top_idx, then we might be racing with a concurrent
+  // pop_top operation.
+
+  uint64_t local_top_tag = UNPACK_TAG(local_top);
+  uint64_t desired_top = PACK_TAGIDX(local_top_tag+1, local_top_idx);
+
+  if (local_bot < local_top_idx) {
+    // We are racing with a concurrent pop_top, but we already lost the race.
+    // Revert the bot index to match the top, to indicate an empty deque.
+    __atomic_store_n(bot, local_top_idx, __ATOMIC_RELEASE);
+    __atomic_store_n(top, desired_top, __ATOMIC_SEQ_CST);
+    return fail_value;
+  }
+  else {
+    // We are racing with a concurrent pop_top, but we haven't lost the race yet
+    uint64_t found_top = __sync_val_compare_and_swap(top, local_top, desired_top);
+    if (found_top == local_top) {
+      // We won the race
+      ABP_deque_check_successful_pop(elem, fail_value);
+      return elem;
+    }
+    else {
+      // We lost the race
+
+      // This could be an assertion, but I'd rather see the error explicitly,
+      // even in optimized builds.
+      if (UNPACK_IDX(found_top) != local_bot+1 ||
+          UNPACK_TAG(found_top) != local_top_tag)
+      {
+        DIE("Scheduler bug: corrupted top");
+      }
+
+      uint64_t new_top = PACK_TAGIDX(local_top_tag+1, local_bot+1);
+      __atomic_store_n(bot, local_bot+1, __ATOMIC_RELEASE);
+      __atomic_store_n(top, new_top, __ATOMIC_SEQ_CST);
+      return fail_value;
+    }
+  }
+}
+
+
+objptr ABP_deque_try_pop_top(
+  __attribute__ ((unused)) GC_state s,
+  objptr top_op,
+  objptr bot_op,
+  objptr data_op,
+  objptr fail_value)
+{
+  uint64_t* top = (uint64_t*)objptrToPointer(top_op, NULL);
+  uint32_t* bot = (uint32_t*)objptrToPointer(bot_op, NULL);
+  objptr* data = (objptr*)objptrToPointer(data_op, NULL);
+
+  uint64_t local_top = __atomic_load_n(top, __ATOMIC_ACQUIRE);
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  uint32_t local_bot = __atomic_load_n(bot, __ATOMIC_ACQUIRE);
+
+  uint32_t local_top_idx = UNPACK_IDX(local_top);
+
+  if (local_bot <= local_top_idx) {
+    return fail_value;
+  }
+
+  objptr elem = __atomic_load_n(data + local_top_idx, __ATOMIC_ACQUIRE);
+  uint64_t local_top_tag = UNPACK_TAG(local_top);
+  uint64_t desired_top = PACK_TAGIDX(local_top_tag, local_top_idx+1);
+
+  if (__sync_bool_compare_and_swap(top, local_top, desired_top)) {
+    ABP_deque_check_successful_pop(elem, fail_value);
+    return elem;
+  }
+  else {
+    return fail_value;
+  }
+}
+
+
+PRIVATE void ABP_deque_set_depth(
+  __attribute__ ((unused)) GC_state s,
+  objptr top_op,
+  objptr bot_op,
+  __attribute__ ((unused)) objptr data_op,
+  uint32_t desired_depth)
+{
+  uint64_t* top = (uint64_t*)objptrToPointer(top_op, NULL);
+  uint32_t* bot = (uint32_t*)objptrToPointer(bot_op, NULL);
+
+  uint64_t local_top = __atomic_load_n(top, __ATOMIC_ACQUIRE);
+  uint32_t local_bot = __atomic_load_n(bot, __ATOMIC_ACQUIRE);
+
+  uint32_t local_top_idx = UNPACK_IDX(local_top);
+  uint32_t local_top_tag = UNPACK_TAG(local_top);
+  uint64_t desired_top = PACK_TAGIDX(local_top_tag+1, desired_depth);
+
+  if (local_top_idx != local_bot) {
+    DIE(
+      "Bug! Attempt to set depth of non-empty deque! tag=%u top=%u bot=%u desired_depth=%u",
+      local_top_tag,
+      local_top_idx,
+      local_bot,
+      desired_depth
+    );
+  }
+
+  /* Have to make sure the intermediate state of the deque still appears to
+   * be empty, i.e., we need to maintain bot index <= top index. So, if the
+   * desired depth is smaller, we move the bot first. Otherwise, we move th
+   * top first.
+   */
+
+  if (desired_depth == local_bot) {
+    return;
+  }
+  else if (desired_depth < local_bot) {
+    __atomic_store_n(bot, desired_depth, __ATOMIC_SEQ_CST);
+    __atomic_store_n(top, desired_top, __ATOMIC_SEQ_CST);
+  }
+  else {
+    __atomic_store_n(top, desired_top, __ATOMIC_SEQ_CST);
+    __atomic_store_n(bot, desired_depth, __ATOMIC_SEQ_CST);
+  }
+}

--- a/runtime/gc/abp-deque.h
+++ b/runtime/gc/abp-deque.h
@@ -1,0 +1,47 @@
+/* Copyright (C) 2024-2025 Sam Westrick.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ */
+
+#if (defined (MLTON_GC_INTERNAL_BASIS))
+
+// Try to push `elem_to_push`, returning success or failure if the deque
+// is at capacity.
+PRIVATE Bool ABP_deque_push_bot(
+  GC_state s,
+  objptr top,
+  objptr bot,
+  objptr data,
+  objptr elem_to_push
+);
+
+
+PRIVATE objptr ABP_deque_try_pop_bot(
+  GC_state s,
+  objptr top,
+  objptr bot,
+  objptr data,
+  objptr fail_value   // should be the value NONE, to return in case of failure
+);
+
+
+PRIVATE objptr ABP_deque_try_pop_top(
+  GC_state s,
+  objptr top_op,
+  objptr bot_op,
+  objptr data_op,
+  objptr fail_value   // should be the value NONE, to return in case of failure
+);
+
+
+PRIVATE void ABP_deque_set_depth(
+  GC_state s,
+  objptr top_op,
+  objptr bot_op,
+  objptr data_op,
+  uint32_t desired_depth
+);
+
+
+#endif /* (defined (MLTON_GC_INTERNAL_BASIS)) */

--- a/runtime/gc/local-scope.c
+++ b/runtime/gc/local-scope.c
@@ -1,51 +1,26 @@
-/* Copyright (C) 2019 Sam Westrick
+/* Copyright (C) 2019-2025 Sam Westrick
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 
 bool tryClaimLocalScope(GC_state s) {
-  uint64_t *top = (uint64_t*)objptrToPointer(s->wsQueueTop, NULL);
-  uint32_t *bot = (uint32_t*)objptrToPointer(s->wsQueueBot, NULL);
-
-  uint32_t oldBot = atomicLoadU32(bot);
-  if (oldBot == 0) {
-    return FALSE;
-  }
-
-  uint32_t newBot = oldBot-1;
-  atomicStoreU32(bot, newBot);
-  __sync_synchronize();
-
-  uint64_t oldTop = atomicLoadU64(top);
-  uint32_t idx = UNPACK_IDX(oldTop);
-
-  if (newBot > idx) {
-    return TRUE;
-  }
-
-  if (newBot < idx) {
-    atomicStoreU32(bot, idx);
-    __sync_synchronize();
-    return FALSE;
-  }
-
-  /* In this case, newBot == idx, so we are racing with a concurrent steal, but
-   * we haven't lost the race yet. Despite this, let's be conservative and leave
-   * that one element available for stealing. This has the nice property that
-   * the GC will never interfere with the deque top-idx tag. */
-  atomicStoreU32(bot, oldBot);
-  __sync_synchronize();
-  return FALSE;
+  objptr result = ABP_deque_try_pop_bot(
+    s,
+    s->wsQueueTop,
+    s->wsQueueBot,
+    s->wsQueue,
+    BOGUS_OBJPTR
+  );
+  return (result != BOGUS_OBJPTR);
 }
 
 void releaseLocalScope(GC_state s, uint32_t originalBot) {
   uint32_t *bot = (uint32_t*)objptrToPointer(s->wsQueueBot, NULL);
-  atomicStoreU32(bot, originalBot);
-  __sync_synchronize();
+  __atomic_store_n(bot, originalBot, __ATOMIC_SEQ_CST);
 }
 
 uint32_t pollCurrentLocalScope(GC_state s) {
   uint32_t *bot = (uint32_t*)objptrToPointer(s->wsQueueBot, NULL);
-  return *bot;
+  return __atomic_load_n(bot, __ATOMIC_SEQ_CST);
 }

--- a/runtime/gc/switch-thread.c
+++ b/runtime/gc/switch-thread.c
@@ -23,7 +23,8 @@ void switchToThread(GC_state s, objptr op) {
     assert(otherProcNum != s->procNumber);
     otherProcNum = atomicLoadS32(&(thread->currentProcNum));
   }
-  thread->currentProcNum = s->procNumber;
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  atomicStoreS32(&(thread->currentProcNum), s->procNumber);
 
   if (DEBUG_THREADS) {
     // GC_thread thread;
@@ -78,6 +79,7 @@ void GC_switchToThread (GC_state s, pointer p, size_t ensureBytesFree) {
 
   s->currentThread = BOGUS_OBJPTR;
   /* SAM_NOTE: This write synchronizes with the spinloop in switchToThread (above) */
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
   atomicStoreS32(&(oldCurrentThread->currentProcNum), -1);
 
   // printf("[%d] switchToThread\n  from %p\n    to %p\n",

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -304,6 +304,7 @@ void GC_HH_joinIntoParent(
     GC_MayTerminateThreadRarely(s, &terminateCheckCounter);
     if (terminateCheckCounter == 0) sched_yield();
   }
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
 
 #if ASSERT
   assert(threadop != BOGUS_OBJPTR);


### PR DESCRIPTION
This makes it possible to use the appropriate memory order annotations, to ensure correct compilation on weakly ordered architectures such as ARM.

AFAICT, this fixes #212. On a MacBook Air M2 (2022) I'm no longer seeing these errors in my tests.

I used memory ordering annotations inspired by the ParlayLib implementation:
  https://github.com/cmuparlay/parlaylib/blob/36459f42a84207330eae706c47e6fab712e6a149/include/parlay/internal/work_stealing_deque.h

One difference between our deque and the standard ABP deque is that we use the current top index of the deque to interface between the scheduler and the GC. For example, an empty deque with top=5 indicates that depths 1-4 are out of scope of LGC (because the corresponding tasks have been stolen). So, when our deque becomes empty, rather than reset the top/bottom indices to 0 (as a standard ABP deque would do), we instead keep them set at the current value.

I believe this patch may also fix another subtle bug related to the deque, specifically the tag of the packed tag+idx not being advanced here:
  https://github.com/MPLLang/mpl/blob/70bfe0fc4eef5c5ead66eb2af8698b42185585aa/basis-library/schedulers/shh/queue/DequeABP.sml#L223-L230
I don't have any evidence of a failing test or otherwise, but it seems like it can cause an ABA problem, if another concurrent steal were in-flight at the same index but then managed to succeed later with the same top tag. This patch correctly advances the top tag in this case:
https://github.com/shwestrick/mpl/blob/f6d02f4025ba5df0c2cac533c85db52e68f3dfba/runtime/gc/abp-deque.c#L72-L80