### PR TITLE
fix gcc-14 incompatible-pointer-types error

### DIFF
--- a/include/c-chunk.h
+++ b/include/c-chunk.h
@@ -86,7 +86,7 @@ Real32 ArrayR32_cas(Real32* a, Word64 i, Real32 x, Real32 y) {
 static inline
 Objptr RefP_cas(Objptr* r, Objptr x, Objptr y) {
   Objptr res = __sync_val_compare_and_swap(r, x, y);
-  return Assignable_decheckObjptr(r, res);
+  return Assignable_decheckObjptr((Objptr)r, res);
 }
 
 #define ArrayW8_cas(a, i, x, y) __sync_val_compare_and_swap(((Word8*)(a)) + (i), (x), (y))
@@ -103,7 +103,7 @@ Objptr RefP_cas(Objptr* r, Objptr x, Objptr y) {
 static inline
 Objptr ArrayP_cas(Objptr* a, Word64 i, Objptr x, Objptr y) {
   Objptr res = __sync_val_compare_and_swap(a + i, x, y);
-  return Assignable_decheckObjptr(a, res);
+  return Assignable_decheckObjptr((Objptr)a, res);
 }
 
 static inline void GC_writeBarrier(CPointer s, Objptr obj, CPointer dst, Objptr src) {


### PR DESCRIPTION
GCC-14 no longer allows implicitly casting all pointer types to all other pointer types (https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types), the error message is shown below:

```
../mpl/lib/mlton/include/c-chunk.h: In function ‘RefP_cas’:
../mpl/lib/mlton/include/c-chunk.h:89:35: error: passing argument 1 of ‘Assignable_decheckObjptr’ from incompatible pointer type [-Wincompatible-pointer-types]
   89 |   return Assignable_decheckObjptr(r, res);
      |                                   ^
      |                                   |
      |                                   PointerAux ** {aka unsigned char **}
../mpl/lib/mlton/include/c-chunk.h:59:40: note: expected ‘Objptr’ {aka ‘unsigned char *’} but argument is of type ‘PointerAux **’ {aka ‘unsigned char **’}
   59 | extern Objptr Assignable_decheckObjptr(Objptr, Objptr);
      |                                        ^~~~~~
../mpl/lib/mlton/include/c-chunk.h: In function ‘ArrayP_cas’:
../mpl/lib/mlton/include/c-chunk.h:106:35: error: passing argument 1 of ‘Assignable_decheckObjptr’ from incompatible pointer type [-Wincompatible-pointer-types]
  106 |   return Assignable_decheckObjptr(a, res);
      |                                   ^
      |                                   |
      |                                   PointerAux ** {aka unsigned char **}
../mpl/lib/mlton/include/c-chunk.h:59:40: note: expected ‘Objptr’ {aka ‘unsigned char *’} but argument is of type ‘PointerAux **’ {aka ‘unsigned char **’}
   59 | extern Objptr Assignable_decheckObjptr(Objptr, Objptr);
      |                                        ^~~~~~
```

The fix is simple, just do an explicit cast. Could you please review if there is any potential issues with this fix? Thank you!