### PR TITLE
feat: add Docker arm64 build and revamp docker files

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -15,6 +15,6 @@ COPY . /root/mpl
 WORKDIR /root/mpl
 
 # Build from source, install, and make examples
-RUN make && make install && cd examples && make
+RUN make clean && make && make install && cd examples && make
 
 ENV PATH=/root/mpl/build/bin:$PATH

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,21 @@
+# Debian Sid has ARM64 mlton packages
+FROM debian:sid-20250113
+
+# Install the dependencies. We'll use the ubuntu provided mlton to bootstrap our local build.
+RUN apt-get update -qq \
+ && apt-get install -qq git build-essential libgmp-dev mlton mlton-tools vim \
+ && git clone https://github.com/mlton/mlton.git /root/mlton \
+ && cd /root/mlton \
+ && git checkout on-20241230-release \
+ && make
+
+ENV PATH=/root/mlton/build/bin:$PATH
+
+# Copy the current directory (MPL source root) to a location within the container & move there
+COPY . /root/mpl
+WORKDIR /root/mpl
+
+# Build from source, install, and make examples
+RUN make clean && make && make install && cd examples && make
+
+ENV PATH=/root/mpl/build/bin:$PATH

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,7 +3,8 @@ FROM debian:sid-20250113
 
 # Install the dependencies. We'll use the ubuntu provided mlton to bootstrap our local build.
 RUN apt-get update -qq \
- && apt-get install -qq git build-essential libgmp-dev mlton mlton-tools vim \
+ && apt-get install -qq git \
+ && apt-get install -qq build-essential libgmp-dev mlton mlton-tools vim \
  && git clone https://github.com/mlton/mlton.git /root/mlton \
  && cd /root/mlton \
  && git checkout on-20241230-release \

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -6,7 +6,7 @@ NAME="mlton-run-docker"
 docker image rm $NAME
 
 # build container, and assign it tag $NAME
-docker build -t $NAME .
+docker build -t $NAME -f Dockerfile.$(uname -m) .
 
 # run container with the tag $NAME.
 docker run --rm -it $NAME

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-NAME="mlton-run-docker"
+NAME="mpl-run-docker"
 
 # Remove any containers which already have $NAME.
 docker image rm $NAME
 
 # build container, and assign it tag $NAME
-docker build -t $NAME -f Dockerfile.$(uname -m) .
+PLATFORM=`uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/`
+docker build -t $NAME -f Dockerfile.$PLATFORM .
 
 # run container with the tag $NAME.
 docker run --rm -it $NAME

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,15 @@
+group "default" {
+    targets = ["amd64", "arm64"]
+}
+
+target "amd64" {
+    dockerfile = "Dockerfile.amd64"
+    tags = ["shwestrick/mpl:latest"]
+    platforms = ["linux/amd64"]
+}
+
+target "arm64" {
+    dockerfile = "Dockerfile.arm64"
+    tags = ["shwestrick/mpl:latest"]
+    platforms = ["linux/arm64"]
+}


### PR DESCRIPTION
Support for building Docker images for multiple architectures; see #209 for some context. The arm64 image performs way better and actually is quite close to directly using M1 on my laptop.

To organize the docker files better, it seems `docker buildx bake` is recommended for such use cases. LMK if you think you prefer these to be organized in a different way! For testing you can use `docker buildx bake` which builds two images, one for amd64 and one for arm64.

In addition to the above, the build process now executes `make clean` first before running `make`. This avoids output from any local `make` messing up the `make` command executed in the container.