### PR TITLE
use atomics to ensure correct freelist manipulation

### DIFF
--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -58,9 +58,9 @@ static inline SuperBlockList getFullnessGroup(
   assert(0 <= class && (size_t)class < s->controls->superblockThreshold);
 
   if (fg == COMPLETELY_EMPTY)
-    return &(ball->completelyEmptyGroup);
+    return &(ball->shared.completelyEmptyGroup);
 
-  return &(ball->sizeClassFullnessGroup[class * NUM_FULLNESS_GROUPS + fg]);
+  return &(ball->shared.sizeClassFullnessGroup[class * NUM_FULLNESS_GROUPS + fg]);
 }
 
 
@@ -132,32 +132,35 @@ static void assertBlockAllocatorOkay(GC_state s, BlockAllocator ball) {
 
 #endif
 
+static void initBlockAllocatorShared(GC_state s, SubBlocks *shared) {
+  *shared = (SubBlocks){0};
 
-static void initBlockAllocator(GC_state s, BlockAllocator ball) {
+  shared->sizeClassFullnessGroup =
+    malloc(s->controls->superblockThreshold * NUM_FULLNESS_GROUPS * sizeof(struct SuperBlockList));
+  for (size_t i = 0; i < s->controls->superblockThreshold; i++) {
+    for (int j = 0; j < NUM_FULLNESS_GROUPS; j++) {
+      shared->sizeClassFullnessGroup[i * NUM_FULLNESS_GROUPS + j].firstSuperBlock = NULL;
+    }
+  }
+  shared->completelyEmptyGroup.firstSuperBlock = NULL;
+}
+
+
+static void initBlockAllocatorLocal(GC_state s, BlockAllocator ball) {
+  *ball = (struct BlockAllocator){0};
+  initBlockAllocatorShared(s, &(ball->shared));
+}
+
+
+static void initBlockAllocatorGlobal(GC_state s, GlobalBlockAllocator ball) {
   size_t numMegaBlockSizeClasses =
     s->controls->megablockThreshold - s->controls->superblockThreshold;
 
-  ball->sizeClassFullnessGroup =
-    malloc(s->controls->superblockThreshold * NUM_FULLNESS_GROUPS * sizeof(struct SuperBlockList));
+  *ball = (struct GlobalBlockAllocator){0};
+  initBlockAllocatorShared(s, &(ball->shared));
+
   ball->megaBlockSizeClass =
     malloc(numMegaBlockSizeClasses * sizeof(struct MegaBlockList));
-
-  for (size_t i = 0; i < s->controls->superblockThreshold; i++) {
-    for (int j = 0; j < NUM_FULLNESS_GROUPS; j++) {
-      getFullnessGroup(s, ball, i, j)->firstSuperBlock = NULL;
-    }
-  }
-
-  ball->completelyEmptyGroup.firstSuperBlock = NULL;
-
-  ball->firstFreedByOther = NULL;
-  ball->numBlocksMapped = 0;
-  ball->numBlocksReleased = 0;
-  for (enum BlockPurpose p = 0; p < NUM_BLOCK_PURPOSES; p++) {
-    ball->numBlocksAllocated[p] = 0;
-    ball->numBlocksFreed[p] = 0;
-  }
-
   for (size_t i = 0; i < numMegaBlockSizeClasses; i++) {
     ball->megaBlockSizeClass[i].firstMegaBlock = NULL;
   }
@@ -165,18 +168,17 @@ static void initBlockAllocator(GC_state s, BlockAllocator ball) {
 }
 
 
-BlockAllocator initGlobalBlockAllocator(GC_state s) {
-  s->blockAllocatorGlobal = malloc(sizeof(struct BlockAllocator));
-  initBlockAllocator(s, s->blockAllocatorGlobal);
+GlobalBlockAllocator initGlobalBlockAllocator(GC_state s) {
+  s->blockAllocatorGlobal = malloc(sizeof(struct GlobalBlockAllocator));
+  initBlockAllocatorGlobal(s, s->blockAllocatorGlobal);
   return s->blockAllocatorGlobal;
 }
 
 
-void initLocalBlockAllocator(GC_state s, BlockAllocator globalBall) {
-  // s->controls->blockSize;
+void initLocalBlockAllocator(GC_state s, GlobalBlockAllocator globalBall) {
   s->blockAllocatorGlobal = globalBall;
   s->blockAllocatorLocal = malloc(sizeof(struct BlockAllocator));
-  initBlockAllocator(s, s->blockAllocatorLocal);
+  initBlockAllocatorLocal(s, s->blockAllocatorLocal);
 }
 
 
@@ -393,7 +395,7 @@ static void localFreeBlocks(GC_state s, SuperBlock sb, FreeBlock b) {
 static void clearOutOtherFrees(GC_state s) {
   BlockAllocator local = s->blockAllocatorLocal;
   size_t numFreed = 0;
-  FreeBlock topElem = atomic_exchange(&local->firstFreedByOther, NULL); // claim entire list
+  FreeBlock topElem = atomic_exchange(&local->shared.firstFreedByOther, NULL); // claim entire list
 
   while (topElem != NULL) {
     FreeBlock next = topElem->nextFree;
@@ -414,7 +416,7 @@ static void clearOutOtherFrees(GC_state s) {
 
 
 static void freeMegaBlock(GC_state s, MegaBlock mb, size_t sizeClass) {
-  BlockAllocator global = s->blockAllocatorGlobal;
+  GlobalBlockAllocator global = s->blockAllocatorGlobal;
   size_t nb = mb->numBlocks;
   enum BlockPurpose purpose = mb->purpose;
 
@@ -429,8 +431,8 @@ static void freeMegaBlock(GC_state s, MegaBlock mb, size_t sizeClass) {
       nb,
       (size_t)1 << (s->controls->megablockThreshold - 1));
       
-    __sync_fetch_and_add(&(global->numBlocksFreed[purpose]), nb);
-    __sync_fetch_and_add(&(global->numBlocksReleased), nb);
+    atomic_fetch_add_explicit(&(global->numBlocksFreed[purpose]), nb, memory_order_relaxed);
+    atomic_fetch_add_explicit(&(global->numBlocksReleased), nb, memory_order_relaxed);
     return;
   }
 
@@ -441,7 +443,7 @@ static void freeMegaBlock(GC_state s, MegaBlock mb, size_t sizeClass) {
   global->megaBlockSizeClass[mbClass].firstMegaBlock = mb;
   pthread_mutex_unlock(&(global->megaBlockLock));
 
-  __sync_fetch_and_add(&(global->numBlocksFreed[purpose]), nb);
+  atomic_fetch_add_explicit(&(global->numBlocksFreed[purpose]), nb, memory_order_relaxed);
   return;
 }
 
@@ -452,7 +454,7 @@ static MegaBlock tryFindMegaBlock(
   size_t sizeClass,
   enum BlockPurpose purpose)
 {
-  BlockAllocator global = s->blockAllocatorGlobal;
+  GlobalBlockAllocator global = s->blockAllocatorGlobal;
   assert(sizeClass >= s->controls->superblockThreshold);
 
   if (sizeClass >= s->controls->megablockThreshold)
@@ -480,7 +482,7 @@ static MegaBlock tryFindMegaBlock(
         mb->nextMegaBlock = NULL;
         pthread_mutex_unlock(&(global->megaBlockLock));
 
-        __sync_fetch_and_add(&(global->numBlocksAllocated[purpose]), mb->numBlocks);
+        atomic_fetch_add_explicit(&(global->numBlocksAllocated[purpose]), mb->numBlocks, memory_order_relaxed);
 
         LOG(LM_CHUNK_POOL, LL_INFO,
           "inspected %zu, satisfied large alloc of %zu blocks using megablock of %zu",
@@ -508,9 +510,9 @@ static MegaBlock mmapNewMegaBlock(GC_state s, size_t numBlocks, enum BlockPurpos
     DIE("whoops, mmap didn't align by the block-size.");
   }
 
-  BlockAllocator global = s->blockAllocatorGlobal;
-  __sync_fetch_and_add(&(global->numBlocksMapped), numBlocks);
-  __sync_fetch_and_add(&(global->numBlocksAllocated[purpose]), numBlocks);
+  GlobalBlockAllocator global = s->blockAllocatorGlobal;
+  atomic_fetch_add_explicit(&(global->numBlocksMapped), numBlocks, memory_order_relaxed);
+  atomic_fetch_add_explicit(&(global->numBlocksAllocated[purpose]), numBlocks, memory_order_relaxed);
 
   MegaBlock mb = (MegaBlock)start;
   mb->numBlocks = numBlocks;
@@ -658,8 +660,8 @@ void freeBlocks(GC_state s, Blocks bs, writeFreedBlockInfoFnClosure f) {
   }
 
   /** Otherwise, enqueue for the other proc to handle. */
-  elem->nextFree = atomic_load_explicit(&owner->firstFreedByOther, memory_order_relaxed);
-  while (!atomic_compare_exchange_weak_explicit(&owner->firstFreedByOther,
+  elem->nextFree = atomic_load_explicit(&owner->shared.firstFreedByOther, memory_order_relaxed);
+  while (!atomic_compare_exchange_weak_explicit(&owner->shared.firstFreedByOther,
                                                 &elem->nextFree,
                                                 elem,
                                                 memory_order_acq_rel,
@@ -697,16 +699,18 @@ void queryCurrentBlockUsage(
   }
 
   // query global allocator
-  BlockAllocator global = s->blockAllocatorGlobal;
-  *numBlocksMapped += global->numBlocksMapped;
-  *numBlocksReleased += global->numBlocksReleased;
+  GlobalBlockAllocator global = s->blockAllocatorGlobal;
+  size_t globalMapped = atomic_load_explicit(&(global->numBlocksMapped), memory_order_relaxed);
+  size_t globalReleased = atomic_load_explicit(&(global->numBlocksReleased), memory_order_relaxed);
+  *numBlocksMapped += globalMapped;
+  *numBlocksReleased += globalReleased;
   for (enum BlockPurpose p = 0; p < NUM_BLOCK_PURPOSES; p++) {
-    numBlocksAllocated[p] += global->numBlocksAllocated[p];
-    numBlocksFreed[p] += global->numBlocksFreed[p];
+    numBlocksAllocated[p] += atomic_load_explicit(&(global->numBlocksAllocated[p]), memory_order_relaxed);
+    numBlocksFreed[p] += atomic_load_explicit(&(global->numBlocksFreed[p]), memory_order_relaxed);
   }
 
-  *numGlobalBlocksMapped += global->numBlocksMapped;
-  *numGlobalBlocksReleased += global->numBlocksReleased;
+  *numGlobalBlocksMapped += globalMapped;
+  *numGlobalBlocksReleased += globalReleased;
 }
 
 

--- a/runtime/gc/block-allocator.c
+++ b/runtime/gc/block-allocator.c
@@ -392,17 +392,8 @@ static void localFreeBlocks(GC_state s, SuperBlock sb, FreeBlock b) {
 
 static void clearOutOtherFrees(GC_state s) {
   BlockAllocator local = s->blockAllocatorLocal;
-  FreeBlock topElem = local->firstFreedByOther;
-
-  if (NULL != topElem) {
-    while (TRUE) {
-      if (__sync_bool_compare_and_swap(&(local->firstFreedByOther), topElem, NULL))
-        break;
-      topElem = local->firstFreedByOther;
-    }
-  }
-
   size_t numFreed = 0;
+  FreeBlock topElem = atomic_exchange(&local->firstFreedByOther, NULL); // claim entire list
 
   while (topElem != NULL) {
     FreeBlock next = topElem->nextFree;
@@ -667,12 +658,12 @@ void freeBlocks(GC_state s, Blocks bs, writeFreedBlockInfoFnClosure f) {
   }
 
   /** Otherwise, enqueue for the other proc to handle. */
-  while (TRUE) {
-    FreeBlock oldVal = owner->firstFreedByOther;
-    elem->nextFree = oldVal;
-    if (__sync_bool_compare_and_swap(&(owner->firstFreedByOther), oldVal, elem))
-      break;
-  }
+  elem->nextFree = atomic_load_explicit(&owner->firstFreedByOther, memory_order_relaxed);
+  while (!atomic_compare_exchange_weak_explicit(&owner->firstFreedByOther,
+                                                &elem->nextFree,
+                                                elem,
+                                                memory_order_acq_rel,
+                                                memory_order_relaxed)) {}
 }
 
 

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -68,6 +68,7 @@ typedef struct FreeBlock {
 
 
 struct BlockAllocator;
+struct GlobalBlockAllocator;
 
 
 typedef struct SuperBlock {
@@ -138,8 +139,13 @@ enum FullnessGroup {
   COMPLETELY_EMPTY = 4
 };
 
-typedef struct BlockAllocator {
+typedef struct SubBlocks {
+  struct SuperBlockList *sizeClassFullnessGroup;
+  struct SuperBlockList completelyEmptyGroup;
+  _Atomic(struct FreeBlock *)firstFreedByOther;
+} SubBlocks;
 
+typedef struct BlockAllocator {
   size_t numBlocksMapped;
   size_t numBlocksReleased;
   size_t numBlocksAllocated[NUM_BLOCK_PURPOSES];
@@ -151,25 +157,22 @@ typedef struct BlockAllocator {
     *   2 is neither nearly full nor nearly empty
     *   3 is nearly empty, i.e. less than emptinessFraction in use
     */
-  struct SuperBlockList *sizeClassFullnessGroup;
-
-  /** Completely empty superblocks are special because these can be
-    * reused for any size class.
-    */
-  struct SuperBlockList completelyEmptyGroup;
-
-  /** Concurrent freelist (blocks owned by this proc that were freed by some
-    * other proc). To make the concurrency simpler, these blocks are enqueued
-    * for this proc and then this proc may free them at its convenience.
-    */
-  _Atomic(struct FreeBlock *)firstFreedByOther;
-
-  /** Only used in the global allocator (always NULL in the local allocators).
-    */
-  struct MegaBlockList *megaBlockSizeClass;
-  pthread_mutex_t megaBlockLock;
+  SubBlocks shared;
 
 } *BlockAllocator;
+
+
+typedef struct GlobalBlockAllocator {
+  atomic_size_t numBlocksMapped;
+  atomic_size_t numBlocksReleased;
+  atomic_size_t numBlocksAllocated[NUM_BLOCK_PURPOSES];
+  atomic_size_t numBlocksFreed[NUM_BLOCK_PURPOSES];
+
+  SubBlocks shared;
+
+  struct MegaBlockList *megaBlockSizeClass;
+  pthread_mutex_t megaBlockLock;
+} *GlobalBlockAllocator;
 
 
 typedef struct Blocks {
@@ -181,7 +184,9 @@ typedef struct Blocks {
 #else
 
 struct BlockAllocator;
+struct GlobalBlockAllocator;
 typedef struct BlockAllocator * BlockAllocator;
+typedef struct GlobalBlockAllocator * GlobalBlockAllocator;
 
 #endif // MLTON_GC_INTERNAL_TYPES
 
@@ -189,8 +194,8 @@ typedef struct BlockAllocator * BlockAllocator;
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-BlockAllocator initGlobalBlockAllocator(GC_state s);
-void initLocalBlockAllocator(GC_state s, BlockAllocator globalAllocator);
+GlobalBlockAllocator initGlobalBlockAllocator(GC_state s);
+void initLocalBlockAllocator(GC_state s, GlobalBlockAllocator globalAllocator);
 
 /** Get a pointer to the start of some number of free contiguous blocks. */
 Blocks allocateBlocks(GC_state s, size_t numBlocks);

--- a/runtime/gc/block-allocator.h
+++ b/runtime/gc/block-allocator.h
@@ -10,6 +10,7 @@
   * Paul R. Wilson. Hoard: A Scalable Memory Allocator for Multithreaded
   * Applications. ASPLOS 2000.
   */
+#include <stdatomic.h>
 
 #ifndef BLOCK_ALLOCATOR_H_
 #define BLOCK_ALLOCATOR_H_
@@ -60,7 +61,7 @@ typedef struct DebugKeptFreeBlock {
 
 /** Free blocks are used to the store the freelist. */
 typedef struct FreeBlock {
-  struct FreeBlock *nextFree;
+  _Atomic(struct FreeBlock *)nextFree; // atomic pointer to FreeBlock
   struct SuperBlock *container;
   enum BlockPurpose purpose;
 } *FreeBlock;
@@ -137,7 +138,6 @@ enum FullnessGroup {
   COMPLETELY_EMPTY = 4
 };
 
-
 typedef struct BlockAllocator {
 
   size_t numBlocksMapped;
@@ -162,7 +162,7 @@ typedef struct BlockAllocator {
     * other proc). To make the concurrency simpler, these blocks are enqueued
     * for this proc and then this proc may free them at its convenience.
     */
-  FreeBlock firstFreedByOther;
+  _Atomic(struct FreeBlock *)firstFreedByOther;
 
   /** Only used in the global allocator (always NULL in the local allocators).
     */

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -34,7 +34,7 @@ struct GC_state {
   char **atMLtons; /* Initial @MLton args, processed before command line. */
   int atMLtonsLength;
   volatile uint32_t atomicState;
-  struct BlockAllocator *blockAllocatorGlobal;
+  struct GlobalBlockAllocator *blockAllocatorGlobal;
   struct BlockAllocator *blockAllocatorLocal;
   struct Sampler *blockUsageSampler;
   objptr callFromCHandlerThread; /* Handler for exported C calls (in heap). */


### PR DESCRIPTION
This marks the appropriate fields in `block-allocator.h` with `_Atomic` and uses explicit memory orderings to prevent UB. 
Closes #238 .  It also replaces a CAS with a unconditional atomic exchange when the owner claims the entire list, which is slightly cheaper on 

There are two small extensions that can be made to this patch
1. update the remaining `__sync` compiler primitives with `<stdatomic.h>`
This is a pretty straightforward change what I think we _should_ do for the sake of correctness. The memory order guarantees of `__sync` are dubious at best.
2. use a test-test and set pattern when the owner claims the freelist.
This would be closer to how the CAS code was before. I find dropping the guard made the code a little more straight-to-the-point. Also, not having the guard may also lead to slightly more opportunistic reclamation, since the owner always has the most recent information about the freelist, whereas with the guard, other threads may have enqueued, but the owner locally did not see them yet and thus did not free them.
